### PR TITLE
chore: Enhance .gitignore with editor and OS artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,24 +1,56 @@
-# build output
+# Build output
 dist/
+.output/
+.vercel/
 
-# generated types
+# Generated types
 .astro/
 
-# dependencies
+# Dependencies
 node_modules/
 
-# logs
+# Logs
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
+lerna-debug.log*
 
-# environment variables
+# Environment variables
 .env
+.env.local
 .env.production
+.env.*.local
 
-# macOS-specific files
-.DS_Store
-
-# jetbrains setting folder
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+!.vscode/settings.json
 .idea/
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+.history/
+*.local
+
+# Vim
+*.swp
+*.swo
+*~
+
+# Emacs
+*~
+\#*\#
+.\#*
+
+# OS files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db


### PR DESCRIPTION
## Summary
Enhances `.gitignore` to prevent committing editor-specific and OS-specific files.

This addresses the `.history/` files that were accidentally committed in PR #38 and prevents similar issues in the future.

## Changes
- **Added `.history/`** - Prevents Local History extension files from being committed
- **Added `.vercel/` and `.output/`** - Build and deployment artifacts
- **Enhanced editor ignores** - VS Code (with exceptions for shared settings), Vim, Emacs, Visual Studio
- **Added environment variable patterns** - `.env.*.local` and `.env.local`
- **Added OS-specific files** - Windows thumbnails, macOS Spotlight, Trash files
- **Organized by category** - Makes the file easier to read and maintain

## Why this matters
- Keeps the repository clean from personal tool artifacts
- Prevents accidentally committing sensitive local configs
- Reduces PR noise from irrelevant file changes
- Improves developer experience across different editors/IDEs

Related to PR #38 which has `.history/` files that should not have been committed.

🤖 Generated with Claude Code