### PR TITLE
feat: Implement GitHub Issues-based lesson feedback system (#29)

### DIFF
--- a/src/components/FeedbackForm.tsx
+++ b/src/components/FeedbackForm.tsx
@@ -1,0 +1,133 @@
+import { useState } from "react";
+
+type FeedbackFormProps = {
+    lessonName: string;
+};
+
+export default function FeedbackForm({ lessonName }: FeedbackFormProps) {
+    const [feedbackType, setFeedbackType] = useState("bug");
+    const [description, setDescription] = useState("");
+    const [loading, setLoading] = useState(false);
+    const [message, setMessage] = useState<string | null>(null);
+    const [error, setError] = useState<string | null>(null);
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        setLoading(true);
+        setMessage(null);
+        setError(null);
+
+        try {
+            const res = await fetch("/api/feedback", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    lessonName,
+                    feedbackType,
+                    description
+                })
+            });
+
+            const data = await res.json();
+            if (!res.ok) throw new Error(data.error || "Submission failed");
+
+            setMessage("✅ Feedback submitted successfully!");
+            setDescription("");
+        } catch (err: any) {
+            setError(err.message || "Failed to submit feedback");
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    return (
+        <form onSubmit={handleSubmit}>
+            <h3 style={{ marginBottom: "1rem", color: "#fff" }}>
+                Lesson Feedback
+            </h3>
+
+            {/* Lesson */}
+            <div style={{ marginBottom: "0.75rem" }}>
+                <label style={labelStyle}>Lesson</label>
+                <input
+                    type="text"
+                    value={lessonName}
+                    readOnly
+                    style={inputStyle}
+                />
+            </div>
+
+            {/* Type */}
+            <div style={{ marginBottom: "0.75rem" }}>
+                <label style={labelStyle}>Feedback Type</label>
+                <select
+                    value={feedbackType}
+                    onChange={(e) => setFeedbackType(e.target.value)}
+                    style={inputStyle}
+                >
+                    <option value="bug">Bug</option>
+                    <option value="suggestion">Suggestion</option>
+                    <option value="content-quality">Content Quality</option>
+                </select>
+            </div>
+
+            {/* Description */}
+            <div style={{ marginBottom: "1rem" }}>
+                <label style={labelStyle}>Description</label>
+                <textarea
+                    required
+                    rows={4}
+                    value={description}
+                    onChange={(e) => setDescription(e.target.value)}
+                    style={{ ...inputStyle, resize: "vertical" }}
+                />
+            </div>
+
+            {/* Submit */}
+            <button
+                type="submit"
+                disabled={loading}
+                style={{
+                    padding: "0.5rem 1.25rem",
+                    borderRadius: "8px",
+                    border: "none",
+                    background: loading ? "#4B5563" : "#1295D8",
+                    color: "#fff",
+                    fontWeight: 600,
+                    cursor: loading ? "not-allowed" : "pointer"
+                }}
+            >
+                {loading ? "Submitting..." : "Submit Feedback"}
+            </button>
+
+            {/* Messages */}
+            {message && (
+                <p style={{ marginTop: "0.75rem", color: "#22C55E" }}>
+                    {message}
+                </p>
+            )}
+            {error && (
+                <p style={{ marginTop: "0.75rem", color: "#EF4444" }}>
+                    {error}
+                </p>
+            )}
+        </form>
+    );
+}
+
+const labelStyle = {
+    display: "block",
+    marginBottom: "0.25rem",
+    fontSize: "0.85rem",
+    color: "#CBD5E1"
+};
+
+const inputStyle = {
+    width: "100%",
+    padding: "0.45rem 0.6rem",
+    borderRadius: "6px",
+    border: "1px solid #374151",
+    background: "#111827",
+    color: "#F9FAFB",
+    fontSize: "0.9rem"
+};

--- a/src/components/LessonCard.jsx
+++ b/src/components/LessonCard.jsx
@@ -1,208 +1,193 @@
-import SkillBadge from './SkillBadge.jsx';
-
-// Lesson card component matching student Figma design
-// Features: dark header, light body, skill badge, tag pills
+import { useState } from "react";
+import SkillBadge from "./SkillBadge.jsx";
+import FeedbackForm from "./FeedbackForm.tsx";
 
 export default function LessonCard({ lesson, pathwayIcon }) {
-  if (!lesson) return null;
+    if (!lesson) return null;
 
-  const lessonName = lesson.name || 'Untitled Lesson';
+    const lessonName = lesson.name || "Untitled Lesson";
+    const [showFeedback, setShowFeedback] = useState(false);
 
-  const feedbackUrl =
-      'https://github.com/UC-OSPO-Network/education/issues/new' +
-      '?template=lesson-feedback.yml' +
-      `&title=${encodeURIComponent(`Lesson Feedback: ${lessonName}`)}` +
-      `&body=${encodeURIComponent(`Lesson: ${lessonName}\n\nFeedback:`)}`;
+    // Determine if lesson appears in multiple pathways
+    const isMultiCategory =
+        lesson.learnerCategory &&
+        (lesson.learnerCategory.includes(",") ||
+            lesson.learnerCategory.includes(";"));
 
-  // Determine if lesson appears in multiple pathways
-  const isMultiCategory =
-      lesson.learnerCategory &&
-      (lesson.learnerCategory.includes(',') ||
-          lesson.learnerCategory.includes(';'));
-
-  return (
-      <div
-          style={{
-            position: 'relative',
-            background:
-                'linear-gradient(180deg, #2A2A2A 0%, #2A2A2A 35%, #3A3A3A 35%, #3A3A3A 100%)',
-            borderRadius: '16px',
-            overflow: 'hidden',
-            border: '2px solid #3A3A3A',
-            transition: 'all 0.3s ease',
-            cursor: 'pointer',
-            height: '100%',
-            display: 'flex',
-            flexDirection: 'column'
-          }}
-          onMouseEnter={(e) => {
-            e.currentTarget.style.borderColor = 'var(--uc-light-blue)';
-            e.currentTarget.style.transform = 'translateY(-4px)';
-            e.currentTarget.style.boxShadow =
-                '0 8px 24px rgba(18, 149, 216, 0.4)';
-          }}
-          onMouseLeave={(e) => {
-            e.currentTarget.style.borderColor = '#3A3A3A';
-            e.currentTarget.style.transform = 'translateY(0)';
-            e.currentTarget.style.boxShadow = 'none';
-          }}
-          onClick={() => {
-            if (lesson.url) {
-              window.open(lesson.url, '_blank', 'noopener,noreferrer');
-            }
-          }}
-      >
-        {/* Skill Level Badge */}
-        <SkillBadge level={lesson.educationalLevel} />
-
-        {/* Dark Header Section */}
+    return (
         <div
             style={{
-              padding: '1.5rem',
-              paddingTop: '3.5rem',
-              display: 'flex',
-              alignItems: 'flex-start',
-              gap: '1rem',
-              minHeight: '120px'
+                position: "relative",
+                background:
+                    "linear-gradient(180deg, #2A2A2A 0%, #2A2A2A 35%, #3A3A3A 35%, #3A3A3A 100%)",
+                borderRadius: "16px",
+                overflow: "hidden",
+                border: "2px solid #3A3A3A",
+                transition: "all 0.3s ease",
+                cursor: "pointer",
+                height: "100%",
+                display: "flex",
+                flexDirection: "column"
+            }}
+            onMouseEnter={(e) => {
+                e.currentTarget.style.borderColor = "var(--uc-light-blue)";
+                e.currentTarget.style.transform = "translateY(-4px)";
+                e.currentTarget.style.boxShadow =
+                    "0 8px 24px rgba(18, 149, 216, 0.4)";
+            }}
+            onMouseLeave={(e) => {
+                e.currentTarget.style.borderColor = "#3A3A3A";
+                e.currentTarget.style.transform = "translateY(0)";
+                e.currentTarget.style.boxShadow = "none";
+            }}
+            onClick={() => {
+                if (!showFeedback && lesson.url) {
+                    window.open(lesson.url, "_blank", "noopener,noreferrer");
+                }
             }}
         >
-          {/* Icon */}
-          <div
-              style={{
-                fontSize: '2rem',
-                flexShrink: 0,
-                lineHeight: 1
-              }}
-          >
-            {pathwayIcon || '📚'}
-          </div>
+            {/* Skill Level Badge */}
+            <SkillBadge level={lesson.educationalLevel} />
 
-          {/* Title */}
-          <h3
-              style={{
-                margin: 0,
-                fontSize: '1.2rem',
-                fontWeight: '700',
-                color: '#FFFFFF',
-                lineHeight: '1.4',
-                flex: 1
-              }}
-          >
-            {lessonName}
-          </h3>
-        </div>
-
-        {/* Light Body Section */}
-        <div
-            style={{
-              padding: '1.5rem',
-              flex: 1,
-              display: 'flex',
-              flexDirection: 'column',
-              gap: '1rem'
-            }}
-        >
-          {/* Description */}
-          <p
-              style={{
-                margin: 0,
-                fontSize: '0.95rem',
-                color: '#D4D4D8',
-                lineHeight: '1.6',
-                flex: 1
-              }}
-          >
-            {lesson.description || 'No description available'}
-          </p>
-
-          {/* Feedback Button */}
-          <a
-              href={feedbackUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={(e) => e.stopPropagation()}
-              style={{
-                alignSelf: 'flex-start',
-                fontSize: '0.85rem',
-                color: '#72CDF4',
-                textDecoration: 'underline',
-                cursor: 'pointer'
-              }}
-          >
-            💬 Give Feedback
-          </a>
-
-          {/* Tags and Meta Info */}
-          <div
-              style={{
-                display: 'flex',
-                flexDirection: 'column',
-                gap: '0.75rem'
-              }}
-          >
-            {/* Tag Pills */}
+            {/* Header */}
             <div
                 style={{
-                  display: 'flex',
-                  gap: '0.5rem',
-                  flexWrap: 'wrap'
+                    padding: "1.5rem",
+                    paddingTop: "3.5rem",
+                    display: "flex",
+                    alignItems: "flex-start",
+                    gap: "1rem",
+                    minHeight: "120px"
                 }}
             >
-              {lesson.oss_role &&
-                  lesson.oss_role
-                      .split(',')
-                      .slice(0, 2)
-                      .map((role, idx) => (
-                          <span
-                              key={idx}
-                              style={{
-                                padding: '0.35rem 0.85rem',
-                                background: 'rgba(18, 149, 216, 0.15)',
-                                border: '1px solid rgba(18, 149, 216, 0.3)',
-                                color: '#72CDF4',
-                                borderRadius: '16px',
-                                fontSize: '0.8rem',
-                                fontWeight: '600',
-                                whiteSpace: 'nowrap'
-                              }}
-                          >
-                    {role.trim()}
-                  </span>
-                      ))}
+                <div style={{ fontSize: "2rem", lineHeight: 1 }}>
+                    {pathwayIcon || "📚"}
+                </div>
 
-              {lesson.learningResourceType && (
-                  <span
-                      style={{
-                        padding: '0.35rem 0.85rem',
-                        background: 'rgba(255, 181, 17, 0.15)',
-                        border: '1px solid rgba(255, 181, 17, 0.3)',
-                        color: '#FFB511',
-                        borderRadius: '16px',
-                        fontSize: '0.8rem',
-                        fontWeight: '600',
-                        whiteSpace: 'nowrap'
-                      }}
-                  >
-                {lesson.learningResourceType}
-              </span>
-              )}
-            </div>
-
-            {/* Multi-category indicator */}
-            {isMultiCategory && (
-                <p
+                <h3
                     style={{
-                      margin: 0,
-                      fontSize: '0.8rem',
-                      color: '#9CA3AF',
-                      fontStyle: 'italic'
+                        margin: 0,
+                        fontSize: "1.2rem",
+                        fontWeight: "700",
+                        color: "#FFFFFF",
+                        lineHeight: "1.4",
+                        flex: 1
                     }}
                 >
-                  ✨ This lesson is featured in multiple pathways
+                    {lessonName}
+                </h3>
+            </div>
+
+            {/* Body */}
+            <div
+                style={{
+                    padding: "1.5rem",
+                    flex: 1,
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: "1rem"
+                }}
+            >
+                <p
+                    style={{
+                        margin: 0,
+                        fontSize: "0.95rem",
+                        color: "#D4D4D8",
+                        lineHeight: "1.6"
+                    }}
+                >
+                    {lesson.description || "No description available"}
                 </p>
-            )}
-          </div>
+
+                {/* Feedback Toggle Button */}
+                <button
+                    onClick={(e) => {
+                        e.stopPropagation();
+                        setShowFeedback((prev) => !prev);
+                    }}
+                    style={{
+                        alignSelf: "flex-start",
+                        fontSize: "0.85rem",
+                        background: "none",
+                        border: "none",
+                        color: "#72CDF4",
+                        textDecoration: "underline",
+                        cursor: "pointer",
+                        padding: 0
+                    }}
+                >
+                    💬 {showFeedback ? "Close Feedback" : "Give Feedback"}
+                </button>
+
+                {/* Feedback Form */}
+                {showFeedback && (
+                    <div
+                        onClick={(e) => e.stopPropagation()}
+                        style={{
+                            marginTop: "1rem",
+                            background: "#1F2933",
+                            padding: "1rem",
+                            borderRadius: "12px",
+                            border: "1px solid #374151"
+                        }}
+                    >
+                        <FeedbackForm lessonName={lessonName} />
+                    </div>
+                )}
+
+                {/* Tags */}
+                <div style={{ display: "flex", flexWrap: "wrap", gap: "0.5rem" }}>
+                    {lesson.oss_role &&
+                        lesson.oss_role
+                            .split(",")
+                            .slice(0, 2)
+                            .map((role, idx) => (
+                                <span
+                                    key={idx}
+                                    style={{
+                                        padding: "0.35rem 0.85rem",
+                                        background: "rgba(18, 149, 216, 0.15)",
+                                        border: "1px solid rgba(18, 149, 216, 0.3)",
+                                        color: "#72CDF4",
+                                        borderRadius: "16px",
+                                        fontSize: "0.8rem",
+                                        fontWeight: "600"
+                                    }}
+                                >
+                  {role.trim()}
+                </span>
+                            ))}
+
+                    {lesson.learningResourceType && (
+                        <span
+                            style={{
+                                padding: "0.35rem 0.85rem",
+                                background: "rgba(255, 181, 17, 0.15)",
+                                border: "1px solid rgba(255, 181, 17, 0.3)",
+                                color: "#FFB511",
+                                borderRadius: "16px",
+                                fontSize: "0.8rem",
+                                fontWeight: "600"
+                            }}
+                        >
+              {lesson.learningResourceType}
+            </span>
+                    )}
+                </div>
+
+                {isMultiCategory && (
+                    <p
+                        style={{
+                            margin: 0,
+                            fontSize: "0.8rem",
+                            color: "#9CA3AF",
+                            fontStyle: "italic"
+                        }}
+                    >
+                        ✨ This lesson is featured in multiple pathways
+                    </p>
+                )}
+            </div>
         </div>
-      </div>
-  );
+    );
 }

--- a/src/pages/api/feedback.ts
+++ b/src/pages/api/feedback.ts
@@ -1,0 +1,118 @@
+import type { APIRoute } from "astro";
+
+export const prerender = false;
+
+const OWNER = "UC-OSPO-Network";
+const REPO = "education";
+
+const RATE_LIMIT_WINDOW_MS = 60_000; // 1 minute
+const MAX_REQUESTS = 5;
+const ipRequestMap = new Map<string, number[]>();
+
+export const POST: APIRoute = async ({ request }) => {
+    try {
+
+        const clientIp =
+            request.headers.get("x-forwarded-for") ||
+            request.headers.get("cf-connecting-ip") ||
+            "unknown";
+
+        const now = Date.now();
+        const timestamps = ipRequestMap.get(clientIp) || [];
+
+        const recentRequests = timestamps.filter(
+            (time) => now - time < RATE_LIMIT_WINDOW_MS
+        );
+
+        if (recentRequests.length >= MAX_REQUESTS) {
+            return new Response(
+                JSON.stringify({
+                    error: "Too many feedback submissions. Please try again later."
+                }),
+                { status: 429 }
+            );
+        }
+
+        recentRequests.push(now);
+        ipRequestMap.set(clientIp, recentRequests);
+
+
+        const { lessonName, feedbackType, description } = await request.json();
+
+        if (!lessonName || !feedbackType || !description) {
+            return new Response(
+                JSON.stringify({ error: "Missing required fields" }),
+                { status: 400 }
+            );
+        }
+
+        const allowedTypes = ["bug", "suggestion", "content-quality"];
+        if (!allowedTypes.includes(feedbackType)) {
+            return new Response(
+                JSON.stringify({ error: "Invalid feedback type" }),
+                { status: 400 }
+            );
+        }
+
+        if (description.trim().length < 10) {
+            return new Response(
+                JSON.stringify({
+                    error: "Description must be at least 10 characters long."
+                }),
+                { status: 400 }
+            );
+        }
+
+
+        const title = `[Lesson Feedback] ${lessonName} – ${feedbackType}`;
+        const body = `
+### Lesson
+${lessonName}
+
+### Feedback Type
+${feedbackType}
+
+### Description
+${description}
+
+---
+Submitted via lesson feedback form.
+`;
+
+
+        const response = await fetch(
+            `https://api.github.com/repos/${OWNER}/${REPO}/issues`,
+            {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${import.meta.env.GITHUB_TOKEN}`,
+                    Accept: "application/vnd.github+json",
+                    "X-GitHub-Api-Version": "2022-11-28",
+                    "Content-Type": "application/json"
+                },
+                body: JSON.stringify({
+                    title,
+                    body,
+                    labels: ["lesson-feedback", feedbackType]
+                })
+            }
+        );
+
+        if (!response.ok) {
+            const error = await response.json();
+            return new Response(
+                JSON.stringify({ error: error.message || "GitHub API error" }),
+                { status: response.status }
+            );
+        }
+
+        return new Response(JSON.stringify({ success: true }), {
+            status: 201
+        });
+    } catch (err) {
+        return new Response(
+            JSON.stringify({ error: "Server error" }),
+            { status: 500 }
+        );
+    }
+};


### PR DESCRIPTION
## Add GitHub Issues-based Lesson Feedback

This PR adds an inline lesson feedback system using the GitHub Issues API.

### What’s included
- New server-side API route (`/api/feedback`) to create GitHub issues securely
- Inline feedback form added to lesson cards (no external redirect)
- Automatic labeling (`lesson-feedback`, `bug`, `suggestion`, `content-quality`)
- Basic spam protection (rate limiting + minimum description length)
- Proper success/error handling

### Notes
- API route is server-rendered (`prerender = false`)
- GitHub token will be provided via org secrets in production

Closes #29
