### PR TITLE
Adding audit scripts for ossRole values

### DIFF
--- a/.github/workflows/check-urls.yml
+++ b/.github/workflows/check-urls.yml
@@ -1,0 +1,33 @@
+name: Weekly Lesson URL Check
+
+on:
+  schedule:
+    # Runs at 00:00 every Monday
+    - cron: '0 0 * * 1'
+  workflow_dispatch: # Allows you to run it manually from the Actions tab
+
+jobs:
+  check-urls:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18' # Ensure Node 18+ for native fetch
+
+      - name: Run URL Checker Script
+        run: node scripts/check-lesson-urls.mjs
+
+      - name: Publish Report to Job Summary
+        run: cat scripts/output/url-report.md >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload Report Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: url-audit-report
+          path: scripts/output/url-report.md # Updated path
+          retention-days: 7

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "normalize:lessons": "node scripts/normalize-lessons.js",
     "audit:diff": "node scripts/audit-sheet-json-diff.js",
     "audit:a11y": "node scripts/accessibility/audit.cjs",
+    "audit:oss-roles": "node scripts/audit-oss-roles.mjs",
+    "standardize:oss-roles": "node scripts/standardize-oss-roles.mjs",
     "enhance:phase1": "node scripts/run-phase1.js",
     "enhance:time": "node scripts/estimate-time-required.js",
     "enhance:language": "node scripts/standardize-languages.js",

--- a/scripts/audit-oss-roles.mjs
+++ b/scripts/audit-oss-roles.mjs
@@ -1,0 +1,77 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Emulate __dirname in ESM
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Adjust this path if your JSON files are stored elsewhere.
+// Assuming script is in `scripts/` and JSON files are in `src/content/lessons/`
+const CONTENT_DIR = path.join(__dirname, '../src/content/lessons');
+
+async function auditOSSRoles() {
+  try {
+    // Read all files in the directory
+    const files = await fs.readdir(CONTENT_DIR);
+    const jsonFiles = files.filter(file => file.endsWith('.json'));
+
+    if (jsonFiles.length === 0) {
+      console.log(`No JSON files found in ${CONTENT_DIR}`);
+      return;
+    }
+
+    const rawRoles = new Set();
+    const splitRoles = new Set();
+    let filesWithNoRole = 0;
+
+    for (const file of jsonFiles) {
+      const filePath = path.join(CONTENT_DIR, file);
+      const content = await fs.readFile(filePath, 'utf-8');
+      
+      try {
+        const data = JSON.parse(content);
+        const role = data.ossRole;
+        
+        if (role && typeof role === 'string' && role.trim() !== '') {
+          // 1. Exact raw string for mapping
+          rawRoles.add(role.trim());
+          
+          // 2. Individual terms (comma-separated)
+          const parts = role.split(',').map(r => r.trim()).filter(Boolean);
+          parts.forEach(p => splitRoles.add(p));
+        } else {
+          filesWithNoRole++;
+        }
+      } catch (parseErr) {
+        console.warn(`⚠️ Warning: Could not parse JSON in ${file}`);
+      }
+    }
+
+    // Output the results
+    console.log('==================================================');
+    console.log('OSS ROLE AUDIT');
+    console.log('==================================================');
+    
+    console.log('\n--- 1. Unique ossRole (raw string) ---');
+    console.dir(Array.from(rawRoles).sort(), { maxArrayLength: null });
+    
+    console.log('\n--- 2. Individual ossRole (split by comma) ---');
+    console.dir(Array.from(splitRoles).sort(), { maxArrayLength: null });
+    
+    console.log('\n==================================================');
+    console.log('SUMMARY');
+    console.log(`Total JSON files scanned: ${jsonFiles.length}`);
+    console.log(`Files with missing/empty ossRole: ${filesWithNoRole}`);
+    console.log(`Unique ossRole (raw string) found: ${rawRoles.size}`);
+    console.log(`Unique individual ossRole found: ${splitRoles.size}`);
+    console.log('==================================================');
+
+  } catch (err) {
+    console.error('❌ Error reading the content directory:', err.message);
+    console.error(`Attempted path: ${CONTENT_DIR}`);
+    console.error('Please ensure the CONTENT_DIR path accurately points to your JSON files.');
+  }
+}
+
+auditOSSRoles();

--- a/scripts/check-lesson-urls.mjs
+++ b/scripts/check-lesson-urls.mjs
@@ -1,0 +1,153 @@
+/**
+ * HOW TO RUN:
+ * Ensure you are using Node 18 or higher.
+ * Run from the root of your project:
+ * node scripts/check-lesson-urls.mjs
+ * * Output: Generates a `url-report.md` file to ../scripts/output/.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const CONTENT_DIR = path.join(__dirname, '../src/content/lessons');
+const REPORT_FILE = path.join(__dirname, '../scripts/output/url-report.md');
+
+// Configuration
+const TIMEOUT_MS = 8000;
+const MAX_RETRIES = 2;
+
+/**
+ * Validates a single URL with retries, timeout, and redirect tracking
+ */
+async function checkUrl(url, retries = MAX_RETRIES) {
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+    try {
+      // Use redirect: 'manual' so fetch doesn't auto-follow, allowing us to catch the 3xx codes
+      const response = await fetch(url, {
+        method: 'HEAD',
+        redirect: 'manual',
+        signal: controller.signal,
+        headers: {
+          // A standard User-Agent prevents basic bot-blocking (like Cloudflare 403s)
+          'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+        }
+      });
+
+      clearTimeout(timeoutId);
+
+      // Handle Success
+      if (response.ok) {
+        return { status: '✅ OK', code: response.status };
+      }
+      
+      // Handle Redirects (300-399)
+      if (response.status >= 300 && response.status < 400) {
+        const location = response.headers.get('location') || 'Unknown location';
+        return { status: '⚠️ Redirect', code: response.status, details: `→ ${location}` };
+      }
+
+      // Handle Errors (400+)
+      // Note: Some servers block HEAD requests with a 405 or 403. In a highly advanced script, 
+      // you might fallback to a GET request here, but for now we report the error.
+      return { status: '❌ Error', code: response.status, details: response.statusText };
+
+    } catch (error) {
+      clearTimeout(timeoutId);
+      
+      // If it's the last attempt, report the failure
+      if (attempt === retries) {
+        const isTimeout = error.name === 'AbortError';
+        return { 
+          status: '❌ Dead', 
+          code: 'N/A', 
+          details: isTimeout ? `Timeout after ${TIMEOUT_MS}ms` : error.message 
+        };
+      }
+      // Otherwise, loop continues and it retries
+    }
+  }
+}
+
+async function runAudit() {
+  console.log('🔍 Starting Lesson URL Audit...');
+  
+  const files = await fs.readdir(CONTENT_DIR);
+  const jsonFiles = files.filter(f => f.endsWith('.json'));
+  
+  const results = [];
+  let checkedCount = 0;
+
+  for (const file of jsonFiles) {
+    const filePath = path.join(CONTENT_DIR, file);
+    const content = await fs.readFile(filePath, 'utf-8');
+    
+    let data;
+    try {
+      data = JSON.parse(content);
+    } catch (e) {
+      console.warn(`⚠️ Skipping ${file} - Invalid JSON`);
+      continue;
+    }
+
+    const url = data.url;
+    const lessonName = data.title || file; // Fallback to filename if title is missing
+
+    if (!url) {
+      results.push({ lesson: lessonName, file, url: 'MISSING', status: '❌ Dead', code: 'N/A', details: 'No URL field found' });
+      continue;
+    }
+
+    process.stdout.write(`Checking [${checkedCount + 1}/${jsonFiles.length}] ${file}... `);
+    const result = await checkUrl(url);
+    console.log(result.status);
+    
+    results.push({
+      lesson: lessonName,
+      file,
+      url,
+      ...result
+    });
+    
+    checkedCount++;
+    
+    // Slight artificial delay to prevent rate-limiting when hitting the same domain rapidly
+    await new Promise(resolve => setTimeout(resolve, 300));
+  }
+
+  // Generate Markdown Report
+  console.log('\n📝 Generating Markdown Report...');
+  
+  let mdContent = `# Lesson URL Audit Report\n\n`;
+  mdContent += `*Generated on: ${new Date().toUTCString()}*\n\n`;
+  mdContent += `| Status | Code | Lesson (File) | URL | Details |\n`;
+  mdContent += `| :--- | :--- | :--- | :--- | :--- |\n`;
+
+  // Sort results: Dead/Errors first, then Redirects, then OKs
+  results.sort((a, b) => {
+    if (a.status.includes('❌') && !b.status.includes('❌')) return -1;
+    if (!a.status.includes('❌') && b.status.includes('❌')) return 1;
+    if (a.status.includes('⚠️') && !b.status.includes('⚠️')) return -1;
+    if (!a.status.includes('⚠️') && b.status.includes('⚠️')) return 1;
+    return 0;
+  });
+
+  results.forEach(r => {
+    const detailsStr = r.details ? r.details : '';
+    mdContent += `| ${r.status} | ${r.code} | **${r.lesson}**<br>(\`${r.file}\`) | [Link](${r.url}) | ${detailsStr} |\n`;
+  });
+
+  await fs.writeFile(REPORT_FILE, mdContent, 'utf-8');
+  
+  console.log('==================================================');
+  console.log(`✅ Audit complete! Checked ${checkedCount} URLs.`);
+  console.log(`📄 Report saved to: ${REPORT_FILE}`);
+  console.log('==================================================');
+}
+
+runAudit();

--- a/scripts/metadata-report.mjs
+++ b/scripts/metadata-report.mjs
@@ -1,0 +1,144 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Input: where your JSON files live
+const CONTENT_DIR = path.join(__dirname, '../src/content/lessons');
+// Output: where the report will be saved (scripts/output/)
+const OUTPUT_DIR = path.join(__dirname, 'output');
+const OUTPUT_FILE = path.join(OUTPUT_DIR, 'metadata-report.md');
+
+async function generateReport() {
+  try {
+    const files = await fs.readdir(CONTENT_DIR);
+    const jsonFiles = files.filter(file => file.endsWith('.json'));
+
+    if (jsonFiles.length === 0) {
+      console.error(`No JSON files found in ${CONTENT_DIR}`);
+      return;
+    }
+
+    const reportData = [];
+    let keepCandidateCount = 0;
+
+    for (const file of jsonFiles) {
+      const filePath = path.join(CONTENT_DIR, file);
+      const content = await fs.readFile(filePath, 'utf-8');
+      
+      try {
+        const data = JSON.parse(content);
+        
+        const missingFields = [];
+        let score = 0;
+        const totalScoreFields = 8;
+        
+        // 1. Description
+        if (!data.description || data.description.trim().length < 50) {
+          missingFields.push('description (missing or < 50 chars)');
+        } else { score++; }
+
+        // 2-7. Simple empty checks
+        const simpleFields = [
+          'learnerCategory', 'subTopic', 'learningObjectives', 
+          'timeRequired', 'ossRole', 'audience' // Note: audience is not in config.ts schema but requested in prompt
+        ];
+        
+        for (const field of simpleFields) {
+          if (!data[field] || (typeof data[field] === 'string' && data[field].trim() === '')) {
+            missingFields.push(field);
+          } else { score++; }
+        }
+
+        // 8. Educational Level
+        if (!data.educationalLevel || data.educationalLevel === 'Unknown' || data.educationalLevel.trim() === '') {
+          missingFields.push("educationalLevel (missing or 'Unknown')");
+        } else { score++; }
+
+        // Keep Status Check
+        const isKeepCandidate = data.keepStatus === 'keepCandidate';
+        if (isKeepCandidate) {
+          keepCandidateCount++;
+        }
+
+        reportData.push({
+          file,
+          name: data.name || file,
+          percentage: Math.round((score / totalScoreFields) * 100),
+          missingFields,
+          isKeepCandidate
+        });
+
+      } catch (parseErr) {
+        console.warn(`⚠️ Warning: Could not parse JSON in ${file}`);
+      }
+    }
+
+    // Sort: Lowest completeness first.
+    reportData.sort((a, b) => {
+      if (a.percentage !== b.percentage) {
+        return a.percentage - b.percentage;
+      }
+      return a.file.localeCompare(b.file);
+    });
+
+    // --- Generate Markdown Output ---
+    let md = `# Lesson Metadata Completeness Report\n\n`;
+    md += `*Generated on: ${new Date().toLocaleDateString()}*\n\n`;
+    
+    md += `## 📊 Summary\n`;
+    md += `- **Total Lessons Scanned:** ${jsonFiles.length}\n`;
+    md += `- **Lessons Needing Committee Keep/Drop Decision:** ${keepCandidateCount}\n\n`;
+
+    md += `## ⚠️ Action Required: \`keepCandidate\` Status\n`;
+    md += `The following lessons still have \`keepStatus: "keepCandidate"\` and need a final keep/drop decision from the committee.\n\n`;
+    
+    const keepCandidates = reportData.filter(d => d.isKeepCandidate);
+    if (keepCandidates.length > 0) {
+      keepCandidates.forEach(d => {
+        md += `- **${d.file}** (${d.name})\n`;
+      });
+    } else {
+      md += `*All lessons have a finalized keepStatus! 🎉*\n`;
+    }
+    md += `\n---\n\n`;
+
+    md += `## 📋 Completeness Rankings (Lowest to Highest)\n`;
+    md += `Prioritize the lessons at the top of this list for metadata entry.\n\n`;
+
+    reportData.forEach(d => {
+      let health = '🔴';
+      if (d.percentage >= 80) health = '🟢';
+      else if (d.percentage >= 50) health = '🟡';
+
+      md += `### ${health} ${d.file} (${d.percentage}% Complete)\n`;
+      md += `**Name:** ${d.name}\n\n`;
+      
+      if (d.missingFields.length > 0) {
+        md += `**Missing or Incomplete Fields:**\n`;
+        d.missingFields.forEach(f => {
+          md += `- ${f}\n`;
+        });
+      } else {
+        md += `*All key metadata fields are complete!* ✨\n`;
+      }
+      md += `\n`;
+    });
+
+    // --- Save to File ---
+    // 1. Create the output directory if it doesn't exist
+    await fs.mkdir(OUTPUT_DIR, { recursive: true });
+    
+    // 2. Write the file
+    await fs.writeFile(OUTPUT_FILE, md, 'utf-8');
+    
+    console.log(`✅ Success! Report saved to: ${OUTPUT_FILE}`);
+
+  } catch (err) {
+    console.error('❌ Error reading the content directory or writing the file:', err.message);
+  }
+}
+
+generateReport();

--- a/scripts/output/metadata-report.md
+++ b/scripts/output/metadata-report.md
@@ -1,0 +1,634 @@
+# Lesson Metadata Completeness Report
+
+*Generated on: 3/4/2026*
+
+## 📊 Summary
+- **Total Lessons Scanned:** 59
+- **Lessons Needing Committee Keep/Drop Decision:** 32
+
+## ⚠️ Action Required: `keepCandidate` Status
+The following lessons still have `keepStatus: "keepCandidate"` and need a final keep/drop decision from the committee.
+
+- **how-to-contribute-to-open-source.json** (How to Contribute to Open Source)
+- **reproducible-computational-environments-using-containers.json** (Reproducible Computational Environments using Containers)
+- **r-packaging.json** (R Packaging)
+- **building-better-research-software.json** (Building Better Research Software)
+- **intermediate-research-software-development-skills-python-lesson-material.json** (Intermediate Research Software Development Skills (Python) Lesson Material)
+- **python-packaging.json** (Python Packaging)
+- **best-practices-for-maintainers.json** (Best Practices for Maintainers)
+- **cicd-for-research-software-with-gitlab-ci.json** (CI/CD for Research Software with GitLab CI)
+- **collaboration-in-open-research-projects.json** (Collaboration in Open Research Projects)
+- **collaborative-git-for-teams.json** (Collaborative Git for Teams)
+- **finding-users-for-your-project.json** (Finding Users for Your Project)
+- **introduction-to-git.json** (Introduction to Git)
+- **metrics.json** (Metrics)
+- **social-coding-and-open-source-collaboration.json** (Social Coding and Open Source Collaboration)
+- **starting-an-open-source-project.json** (Starting an Open Source Project)
+- **testing-and-test-driven-development.json** (Testing and Test-Driven Development)
+- **continuous-integration-and-delivery-with-github-actions.json** (Continuous Integration and Delivery with GitHub Actions)
+- **effective-code-review.json** (Effective Code Review)
+- **intermediate-python-development.json** (Intermediate Python Development)
+- **introduction-to-docker-for-research-note-this-is-now-called-introduction-to-docker-and-podman.json** (Introduction to Docker for Research  NOTE THIS IS NOW CALLED Introduction to Docker and Podman)
+- **issue-tracking-with-github.json** (Issue Tracking with GitHub)
+- **leadership-and-governance.json** (Leadership and Governance)
+- **making-good-pull-requests.json** (Making Good Pull Requests)
+- **modular-programming-with-python.json** (Modular Programming with Python)
+- **python-package-development-best-practices.json** (Python Package Development Best Practices)
+- **python-packaging-for-beginners.json** (Python Packaging for Beginners)
+- **reproducible-research.json** (Reproducible Research)
+- **research-software-engineering-with-python-course.json** (Research Software Engineering with Python  Course)
+- **understanding-software-licensing.json** (Understanding Software Licensing)
+- **unit-testing-and-tdd-in-python.json** (Unit Testing and TDD in Python)
+- **writing-documentation-for-software-projects.json** (Writing Documentation for Software Projects)
+- **building-community.json** (Building Community)
+
+---
+
+## 📋 Completeness Rankings (Lowest to Highest)
+Prioritize the lessons at the top of this list for metadata entry.
+
+### 🔴 coordinate-reference-systems.json (0% Complete)
+**Name:** Coordinate Reference Systems
+
+**Missing or Incomplete Fields:**
+- description (missing or < 50 chars)
+- learnerCategory
+- subTopic
+- learningObjectives
+- timeRequired
+- ossRole
+- audience
+- educationalLevel (missing or 'Unknown')
+
+### 🔴 developing-your-data-science-portfolio.json (0% Complete)
+**Name:** Developing Your Data Science Portfolio
+
+**Missing or Incomplete Fields:**
+- description (missing or < 50 chars)
+- learnerCategory
+- subTopic
+- learningObjectives
+- timeRequired
+- ossRole
+- audience
+- educationalLevel (missing or 'Unknown')
+
+### 🔴 geocoding.json (0% Complete)
+**Name:** Geocoding
+
+**Missing or Incomplete Fields:**
+- description (missing or < 50 chars)
+- learnerCategory
+- subTopic
+- learningObjectives
+- timeRequired
+- ossRole
+- audience
+- educationalLevel (missing or 'Unknown')
+
+### 🔴 intermediate-python-next-level-data-visualization.json (0% Complete)
+**Name:** Intermediate Python: next-level Data Visualization
+
+**Missing or Incomplete Fields:**
+- description (missing or < 50 chars)
+- learnerCategory
+- subTopic
+- learningObjectives
+- timeRequired
+- ossRole
+- audience
+- educationalLevel (missing or 'Unknown')
+
+### 🔴 intermediate-python.json (0% Complete)
+**Name:** Intermediate Python
+
+**Missing or Incomplete Fields:**
+- description (missing or < 50 chars)
+- learnerCategory
+- subTopic
+- learningObjectives
+- timeRequired
+- ossRole
+- audience
+- educationalLevel (missing or 'Unknown')
+
+### 🔴 intermediate-r-next-level-data-visualization.json (0% Complete)
+**Name:** Intermediate R: Next-level Data Visualization
+
+**Missing or Incomplete Fields:**
+- description (missing or < 50 chars)
+- learnerCategory
+- subTopic
+- learningObjectives
+- timeRequired
+- ossRole
+- audience
+- educationalLevel (missing or 'Unknown')
+
+### 🔴 intermediate-r.json (0% Complete)
+**Name:** Intermediate R
+
+**Missing or Incomplete Fields:**
+- description (missing or < 50 chars)
+- learnerCategory
+- subTopic
+- learningObjectives
+- timeRequired
+- ossRole
+- audience
+- educationalLevel (missing or 'Unknown')
+
+### 🔴 introduction-to-basic-statistics-with-r.json (0% Complete)
+**Name:** Introduction to Basic Statistics with R
+
+**Missing or Incomplete Fields:**
+- description (missing or < 50 chars)
+- learnerCategory
+- subTopic
+- learningObjectives
+- timeRequired
+- ossRole
+- audience
+- educationalLevel (missing or 'Unknown')
+
+### 🔴 introduction-to-desktop-gis-with-qgis.json (0% Complete)
+**Name:** Introduction to Desktop GIS with QGIS
+
+**Missing or Incomplete Fields:**
+- description (missing or < 50 chars)
+- learnerCategory
+- subTopic
+- learningObjectives
+- timeRequired
+- ossRole
+- audience
+- educationalLevel (missing or 'Unknown')
+
+### 🔴 introduction-to-remote-computing.json (0% Complete)
+**Name:** Introduction to Remote Computing
+
+**Missing or Incomplete Fields:**
+- description (missing or < 50 chars)
+- learnerCategory
+- subTopic
+- learningObjectives
+- timeRequired
+- ossRole
+- audience
+- educationalLevel (missing or 'Unknown')
+
+### 🔴 introduction-to-sql-for-querying-databases.json (0% Complete)
+**Name:** Introduction to SQL for Querying Databases
+
+**Missing or Incomplete Fields:**
+- description (missing or < 50 chars)
+- learnerCategory
+- subTopic
+- learningObjectives
+- timeRequired
+- ossRole
+- audience
+- educationalLevel (missing or 'Unknown')
+
+### 🔴 introduction-to-unix-command-line.json (0% Complete)
+**Name:** Introduction to Unix Command Line
+
+**Missing or Incomplete Fields:**
+- description (missing or < 50 chars)
+- learnerCategory
+- subTopic
+- learningObjectives
+- timeRequired
+- ossRole
+- audience
+- educationalLevel (missing or 'Unknown')
+
+### 🔴 introduction-to-version-control-with-git.json (0% Complete)
+**Name:** Introduction to Version Control with Git.
+
+**Missing or Incomplete Fields:**
+- description (missing or < 50 chars)
+- learnerCategory
+- subTopic
+- learningObjectives
+- timeRequired
+- ossRole
+- audience
+- educationalLevel (missing or 'Unknown')
+
+### 🔴 julia-basics.json (0% Complete)
+**Name:** Julia Basics
+
+**Missing or Incomplete Fields:**
+- description (missing or < 50 chars)
+- learnerCategory
+- subTopic
+- learningObjectives
+- timeRequired
+- ossRole
+- audience
+- educationalLevel (missing or 'Unknown')
+
+### 🔴 overview-of-databases-and-data-storage.json (0% Complete)
+**Name:** Overview of Databases and Data Storage
+
+**Missing or Incomplete Fields:**
+- description (missing or < 50 chars)
+- learnerCategory
+- subTopic
+- learningObjectives
+- timeRequired
+- ossRole
+- audience
+- educationalLevel (missing or 'Unknown')
+
+### 🔴 overview-of-remote-and-high-performance-computing-hpc.json (0% Complete)
+**Name:** Overview of Remote and High Performance Computing (HPC)
+
+**Missing or Incomplete Fields:**
+- description (missing or < 50 chars)
+- learnerCategory
+- subTopic
+- learningObjectives
+- timeRequired
+- ossRole
+- audience
+- educationalLevel (missing or 'Unknown')
+
+### 🔴 principles-of-data-visualization-from-perception-to-statistical-graphics.json (0% Complete)
+**Name:** Principles of Data Visualization from PErception to Statistical Graphics
+
+**Missing or Incomplete Fields:**
+- description (missing or < 50 chars)
+- learnerCategory
+- subTopic
+- learningObjectives
+- timeRequired
+- ossRole
+- audience
+- educationalLevel (missing or 'Unknown')
+
+### 🔴 python-basics.json (0% Complete)
+**Name:** Python Basics
+
+**Missing or Incomplete Fields:**
+- description (missing or < 50 chars)
+- learnerCategory
+- subTopic
+- learningObjectives
+- timeRequired
+- ossRole
+- audience
+- educationalLevel (missing or 'Unknown')
+
+### 🔴 r-basics.json (0% Complete)
+**Name:** R Basics
+
+**Missing or Incomplete Fields:**
+- description (missing or < 50 chars)
+- learnerCategory
+- subTopic
+- learningObjectives
+- timeRequired
+- ossRole
+- audience
+- educationalLevel (missing or 'Unknown')
+
+### 🔴 reproducibility-principles-and-practices.json (0% Complete)
+**Name:** Reproducibility Principles and Practices
+
+**Missing or Incomplete Fields:**
+- description (missing or < 50 chars)
+- learnerCategory
+- subTopic
+- learningObjectives
+- timeRequired
+- ossRole
+- audience
+- educationalLevel (missing or 'Unknown')
+
+### 🔴 reproducible-research-for-teams-with-github.json (0% Complete)
+**Name:** Reproducible Research for Teams with GitHub
+
+**Missing or Incomplete Fields:**
+- description (missing or < 50 chars)
+- learnerCategory
+- subTopic
+- learningObjectives
+- timeRequired
+- ossRole
+- audience
+- educationalLevel (missing or 'Unknown')
+
+### 🔴 responsible-data-science.json (0% Complete)
+**Name:** Responsible Data Science
+
+**Missing or Incomplete Fields:**
+- description (missing or < 50 chars)
+- learnerCategory
+- subTopic
+- learningObjectives
+- timeRequired
+- ossRole
+- audience
+- educationalLevel (missing or 'Unknown')
+
+### 🔴 spatial-sql-with-spatialite.json (0% Complete)
+**Name:** Spatial SQL with SpatiaLite
+
+**Missing or Incomplete Fields:**
+- description (missing or < 50 chars)
+- learnerCategory
+- subTopic
+- learningObjectives
+- timeRequired
+- ossRole
+- audience
+- educationalLevel (missing or 'Unknown')
+
+### 🔴 how-to-contribute-to-open-source.json (13% Complete)
+**Name:** How to Contribute to Open Source
+
+**Missing or Incomplete Fields:**
+- description (missing or < 50 chars)
+- subTopic
+- learningObjectives
+- timeRequired
+- ossRole
+- audience
+- educationalLevel (missing or 'Unknown')
+
+### 🔴 reproducible-computational-environments-using-containers.json (25% Complete)
+**Name:** Reproducible Computational Environments using Containers
+
+**Missing or Incomplete Fields:**
+- description (missing or < 50 chars)
+- subTopic
+- learningObjectives
+- timeRequired
+- audience
+- educationalLevel (missing or 'Unknown')
+
+### 🔴 testing-again.json (25% Complete)
+**Name:** TESTING again
+
+**Missing or Incomplete Fields:**
+- description (missing or < 50 chars)
+- subTopic
+- learningObjectives
+- timeRequired
+- ossRole
+- educationalLevel (missing or 'Unknown')
+
+### 🔴 r-packaging.json (38% Complete)
+**Name:** R Packaging
+
+**Missing or Incomplete Fields:**
+- description (missing or < 50 chars)
+- subTopic
+- timeRequired
+- audience
+- educationalLevel (missing or 'Unknown')
+
+### 🟡 building-better-research-software.json (50% Complete)
+**Name:** Building Better Research Software
+
+**Missing or Incomplete Fields:**
+- description (missing or < 50 chars)
+- subTopic
+- timeRequired
+- audience
+
+### 🟡 intermediate-research-software-development-skills-python-lesson-material.json (50% Complete)
+**Name:** Intermediate Research Software Development Skills (Python) Lesson Material
+
+**Missing or Incomplete Fields:**
+- description (missing or < 50 chars)
+- subTopic
+- timeRequired
+- audience
+
+### 🟡 python-packaging.json (50% Complete)
+**Name:** Python Packaging
+
+**Missing or Incomplete Fields:**
+- description (missing or < 50 chars)
+- subTopic
+- timeRequired
+- audience
+
+### 🟡 best-practices-for-maintainers.json (63% Complete)
+**Name:** Best Practices for Maintainers
+
+**Missing or Incomplete Fields:**
+- subTopic
+- learningObjectives
+- timeRequired
+
+### 🟡 cicd-for-research-software-with-gitlab-ci.json (63% Complete)
+**Name:** CI/CD for Research Software with GitLab CI
+
+**Missing or Incomplete Fields:**
+- subTopic
+- learningObjectives
+- timeRequired
+
+### 🟡 collaboration-in-open-research-projects.json (63% Complete)
+**Name:** Collaboration in Open Research Projects
+
+**Missing or Incomplete Fields:**
+- subTopic
+- learningObjectives
+- timeRequired
+
+### 🟡 collaborative-git-for-teams.json (63% Complete)
+**Name:** Collaborative Git for Teams
+
+**Missing or Incomplete Fields:**
+- subTopic
+- learningObjectives
+- timeRequired
+
+### 🟡 example-advanced.json (63% Complete)
+**Name:** Example Advanced Lesson
+
+**Missing or Incomplete Fields:**
+- learningObjectives
+- timeRequired
+- audience
+
+### 🟡 example-beginner.json (63% Complete)
+**Name:** Example Beginner Lesson
+
+**Missing or Incomplete Fields:**
+- learningObjectives
+- timeRequired
+- audience
+
+### 🟡 example.json (63% Complete)
+**Name:** Example Lesson (Replace Me)
+
+**Missing or Incomplete Fields:**
+- learningObjectives
+- timeRequired
+- audience
+
+### 🟡 finding-users-for-your-project.json (63% Complete)
+**Name:** Finding Users for Your Project
+
+**Missing or Incomplete Fields:**
+- subTopic
+- learningObjectives
+- timeRequired
+
+### 🟡 introduction-to-git.json (63% Complete)
+**Name:** Introduction to Git
+
+**Missing or Incomplete Fields:**
+- subTopic
+- learningObjectives
+- timeRequired
+
+### 🟡 metrics.json (63% Complete)
+**Name:** Metrics
+
+**Missing or Incomplete Fields:**
+- subTopic
+- learningObjectives
+- timeRequired
+
+### 🟡 social-coding-and-open-source-collaboration.json (63% Complete)
+**Name:** Social Coding and Open Source Collaboration
+
+**Missing or Incomplete Fields:**
+- subTopic
+- learningObjectives
+- timeRequired
+
+### 🟡 starting-an-open-source-project.json (63% Complete)
+**Name:** Starting an Open Source Project
+
+**Missing or Incomplete Fields:**
+- subTopic
+- learningObjectives
+- timeRequired
+
+### 🟡 testing-and-test-driven-development.json (63% Complete)
+**Name:** Testing and Test-Driven Development
+
+**Missing or Incomplete Fields:**
+- subTopic
+- learningObjectives
+- timeRequired
+
+### 🟡 continuous-integration-and-delivery-with-github-actions.json (75% Complete)
+**Name:** Continuous Integration and Delivery with GitHub Actions
+
+**Missing or Incomplete Fields:**
+- subTopic
+- timeRequired
+
+### 🟡 effective-code-review.json (75% Complete)
+**Name:** Effective Code Review
+
+**Missing or Incomplete Fields:**
+- subTopic
+- timeRequired
+
+### 🟡 intermediate-python-development.json (75% Complete)
+**Name:** Intermediate Python Development
+
+**Missing or Incomplete Fields:**
+- subTopic
+- timeRequired
+
+### 🟡 introduction-to-docker-for-research-note-this-is-now-called-introduction-to-docker-and-podman.json (75% Complete)
+**Name:** Introduction to Docker for Research  NOTE THIS IS NOW CALLED Introduction to Docker and Podman
+
+**Missing or Incomplete Fields:**
+- subTopic
+- timeRequired
+
+### 🟡 issue-tracking-with-github.json (75% Complete)
+**Name:** Issue Tracking with GitHub
+
+**Missing or Incomplete Fields:**
+- subTopic
+- timeRequired
+
+### 🟡 leadership-and-governance.json (75% Complete)
+**Name:** Leadership and Governance
+
+**Missing or Incomplete Fields:**
+- learningObjectives
+- timeRequired
+
+### 🟡 making-good-pull-requests.json (75% Complete)
+**Name:** Making Good Pull Requests
+
+**Missing or Incomplete Fields:**
+- subTopic
+- timeRequired
+
+### 🟡 modular-programming-with-python.json (75% Complete)
+**Name:** Modular Programming with Python
+
+**Missing or Incomplete Fields:**
+- subTopic
+- timeRequired
+
+### 🟡 python-package-development-best-practices.json (75% Complete)
+**Name:** Python Package Development Best Practices
+
+**Missing or Incomplete Fields:**
+- subTopic
+- timeRequired
+
+### 🟡 python-packaging-for-beginners.json (75% Complete)
+**Name:** Python Packaging for Beginners
+
+**Missing or Incomplete Fields:**
+- subTopic
+- timeRequired
+
+### 🟡 reproducible-research.json (75% Complete)
+**Name:** Reproducible Research
+
+**Missing or Incomplete Fields:**
+- subTopic
+- timeRequired
+
+### 🟡 research-software-engineering-with-python-course.json (75% Complete)
+**Name:** Research Software Engineering with Python  Course
+
+**Missing or Incomplete Fields:**
+- subTopic
+- timeRequired
+
+### 🟡 understanding-software-licensing.json (75% Complete)
+**Name:** Understanding Software Licensing
+
+**Missing or Incomplete Fields:**
+- subTopic
+- timeRequired
+
+### 🟡 unit-testing-and-tdd-in-python.json (75% Complete)
+**Name:** Unit Testing and TDD in Python
+
+**Missing or Incomplete Fields:**
+- subTopic
+- timeRequired
+
+### 🟡 writing-documentation-for-software-projects.json (75% Complete)
+**Name:** Writing Documentation for Software Projects
+
+**Missing or Incomplete Fields:**
+- subTopic
+- timeRequired
+
+### 🟢 building-community.json (88% Complete)
+**Name:** Building Community
+
+**Missing or Incomplete Fields:**
+- timeRequired
+

--- a/scripts/output/url-report.md
+++ b/scripts/output/url-report.md
@@ -1,0 +1,65 @@
+# Lesson URL Audit Report
+
+*Generated on: Wed, 11 Mar 2026 06:52:08 GMT*
+
+| Status | Code | Lesson (File) | URL | Details |
+| :--- | :--- | :--- | :--- | :--- |
+| ❌ Error | 404 | **example-advanced.json**<br>(`example-advanced.json`) | [Link](https://example.com/advanced) | Not Found |
+| ❌ Error | 404 | **example-beginner.json**<br>(`example-beginner.json`) | [Link](https://example.com/beginner) | Not Found |
+| ❌ Error | 404 | **intermediate-r-next-level-data-visualization.json**<br>(`intermediate-r-next-level-data-visualization.json`) | [Link](https://ucdavisdatalab.github.io/workshop_intermediate_r/data-visualization-in-r.html) | Not Found |
+| ❌ Error | 404 | **reproducibility-principles-and-practices.json**<br>(`reproducibility-principles-and-practices.json`) | [Link](https://ucdavisdatalab.github.io/workshop_reproducible_research/chapters/index.html) | Not Found |
+| ❌ Dead | N/A | **testing-again.json**<br>(`testing-again.json`) | [Link](MISSING) | No URL field found |
+| ⚠️ Redirect | 301 | **collaboration-in-open-research-projects.json**<br>(`collaboration-in-open-research-projects.json`) | [Link](https://book.the-turing-way.org/collaboration/collaboration) | → /collaboration/collaboration/ |
+| ⚠️ Redirect | 301 | **python-packaging.json**<br>(`python-packaging.json`) | [Link](https://carpentries-incubator.github.io/python_packaging) | → https://carpentries-incubator.github.io/python_packaging/ |
+| ⚠️ Redirect | 301 | **reproducible-research.json**<br>(`reproducible-research.json`) | [Link](https://book.the-turing-way.org/reproducible-research/reproducible-research) | → /reproducible-research/reproducible-research/ |
+| ✅ OK | 200 | **best-practices-for-maintainers.json**<br>(`best-practices-for-maintainers.json`) | [Link](https://opensource.guide/best-practices/) |  |
+| ✅ OK | 200 | **building-better-research-software.json**<br>(`building-better-research-software.json`) | [Link](https://carpentries-incubator.github.io/better-research-software/) |  |
+| ✅ OK | 200 | **building-community.json**<br>(`building-community.json`) | [Link](https://opensource.guide/building-community/) |  |
+| ✅ OK | 200 | **cicd-for-research-software-with-gitlab-ci.json**<br>(`cicd-for-research-software-with-gitlab-ci.json`) | [Link](https://hsf-training.github.io/hsf-training-cicd/) |  |
+| ✅ OK | 200 | **collaborative-git-for-teams.json**<br>(`collaborative-git-for-teams.json`) | [Link](https://coderefinery.github.io/git-collaborative/) |  |
+| ✅ OK | 200 | **continuous-integration-and-delivery-with-github-actions.json**<br>(`continuous-integration-and-delivery-with-github-actions.json`) | [Link](https://intersect-training.org/CI-CD/) |  |
+| ✅ OK | 200 | **coordinate-reference-systems.json**<br>(`coordinate-reference-systems.json`) | [Link](https://ucdavisdatalab.github.io/workshop_coordinate_reference_systems/) |  |
+| ✅ OK | 200 | **developing-your-data-science-portfolio.json**<br>(`developing-your-data-science-portfolio.json`) | [Link](https://ucdavisdatalab.github.io/workshop_portfolios/) |  |
+| ✅ OK | 200 | **effective-code-review.json**<br>(`effective-code-review.json`) | [Link](https://intersect-training.org/Code-Review/) |  |
+| ✅ OK | 200 | **example.json**<br>(`example.json`) | [Link](https://example.com) |  |
+| ✅ OK | 200 | **finding-users-for-your-project.json**<br>(`finding-users-for-your-project.json`) | [Link](https://opensource.guide/finding-users/) |  |
+| ✅ OK | 200 | **geocoding.json**<br>(`geocoding.json`) | [Link](https://github.com/ucdavisdatalab/geocoding-workshop/blob/master/README.md) |  |
+| ✅ OK | 200 | **how-to-contribute-to-open-source.json**<br>(`how-to-contribute-to-open-source.json`) | [Link](https://opensource.guide/how-to-contribute/) |  |
+| ✅ OK | 200 | **intermediate-python-development.json**<br>(`intermediate-python-development.json`) | [Link](https://carpentries-incubator.github.io/python-intermediate-development/) |  |
+| ✅ OK | 200 | **intermediate-python-next-level-data-visualization.json**<br>(`intermediate-python-next-level-data-visualization.json`) | [Link](https://ucdavisdatalab.github.io/workshop_intermediate_python/chapters/05_viz.html) |  |
+| ✅ OK | 200 | **intermediate-python.json**<br>(`intermediate-python.json`) | [Link](https://ucdavisdatalab.github.io/workshop_intermediate_python/chapters/index.html) |  |
+| ✅ OK | 200 | **intermediate-r.json**<br>(`intermediate-r.json`) | [Link](https://ucdavisdatalab.github.io/workshop_intermediate_r/) |  |
+| ✅ OK | 200 | **intermediate-research-software-development-skills-python-lesson-material.json**<br>(`intermediate-research-software-development-skills-python-lesson-material.json`) | [Link](https://carpentries-incubator.github.io/python-intermediate-development/) |  |
+| ✅ OK | 200 | **introduction-to-basic-statistics-with-r.json**<br>(`introduction-to-basic-statistics-with-r.json`) | [Link](https://ucdavisdatalab.github.io/basic_stats_r_1/) |  |
+| ✅ OK | 200 | **introduction-to-desktop-gis-with-qgis.json**<br>(`introduction-to-desktop-gis-with-qgis.json`) | [Link](https://ucdavisdatalab.github.io/Intro-to-Desktop-GIS-with-QGIS/) |  |
+| ✅ OK | 200 | **introduction-to-docker-for-research-note-this-is-now-called-introduction-to-docker-and-podman.json**<br>(`introduction-to-docker-for-research-note-this-is-now-called-introduction-to-docker-and-podman.json`) | [Link](https://hsf-training.github.io/hsf-training-docker/index.html) |  |
+| ✅ OK | 200 | **introduction-to-git.json**<br>(`introduction-to-git.json`) | [Link](https://coderefinery.github.io/git-intro/) |  |
+| ✅ OK | 200 | **introduction-to-remote-computing.json**<br>(`introduction-to-remote-computing.json`) | [Link](https://ucdavisdatalab.github.io/workshop_intro_to_remote_computing/chapters/index.html) |  |
+| ✅ OK | 200 | **introduction-to-sql-for-querying-databases.json**<br>(`introduction-to-sql-for-querying-databases.json`) | [Link](https://ucdavisdatalab.github.io/workshop_intro_to_sql/) |  |
+| ✅ OK | 200 | **introduction-to-unix-command-line.json**<br>(`introduction-to-unix-command-line.json`) | [Link](https://ucdavisdatalab.github.io/workshop_introduction_to_the_command_line/) |  |
+| ✅ OK | 200 | **introduction-to-version-control-with-git.json**<br>(`introduction-to-version-control-with-git.json`) | [Link](https://ucdavisdatalab.github.io/workshop_introduction_to_version_control/chapters/index.html) |  |
+| ✅ OK | 200 | **issue-tracking-with-github.json**<br>(`issue-tracking-with-github.json`) | [Link](https://intersect-training.org/Issue-Tracking/) |  |
+| ✅ OK | 200 | **julia-basics.json**<br>(`julia-basics.json`) | [Link](https://ucjug.github.io/workshop_julia_basics/chapters/index.html) |  |
+| ✅ OK | 200 | **leadership-and-governance.json**<br>(`leadership-and-governance.json`) | [Link](https://opensource.guide/leadership-and-governance/) |  |
+| ✅ OK | 200 | **making-good-pull-requests.json**<br>(`making-good-pull-requests.json`) | [Link](https://intersect-training.org/Making-Good-PRs/) |  |
+| ✅ OK | 200 | **metrics.json**<br>(`metrics.json`) | [Link](https://opensource.guide/metrics/) |  |
+| ✅ OK | 200 | **modular-programming-with-python.json**<br>(`modular-programming-with-python.json`) | [Link](https://coderefinery.github.io/modular-type-along/) |  |
+| ✅ OK | 200 | **overview-of-databases-and-data-storage.json**<br>(`overview-of-databases-and-data-storage.json`) | [Link](https://ucdavisdatalab.github.io/workshop_intro_to_databases/) |  |
+| ✅ OK | 200 | **overview-of-remote-and-high-performance-computing-hpc.json**<br>(`overview-of-remote-and-high-performance-computing-hpc.json`) | [Link](https://video.ucdavis.edu/media/Overview%20of%20Remote%20and%20High%20Performance%20Computing%20(HPC)%20-%202024-02-15/1_zulcobsl) |  |
+| ✅ OK | 200 | **principles-of-data-visualization-from-perception-to-statistical-graphics.json**<br>(`principles-of-data-visualization-from-perception-to-statistical-graphics.json`) | [Link](https://ucdavisdatalab.github.io/workshop_data_viz_principles/) |  |
+| ✅ OK | 200 | **python-basics.json**<br>(`python-basics.json`) | [Link](https://ucdavisdatalab.github.io/workshop_python_basics/chapters/index.html) |  |
+| ✅ OK | 200 | **python-package-development-best-practices.json**<br>(`python-package-development-best-practices.json`) | [Link](https://education.molssi.org/python-package-best-practices/) |  |
+| ✅ OK | 200 | **python-packaging-for-beginners.json**<br>(`python-packaging-for-beginners.json`) | [Link](https://intersect-training.org/packaging/) |  |
+| ✅ OK | 200 | **r-basics.json**<br>(`r-basics.json`) | [Link](https://ucdavisdatalab.github.io/workshop_r_basics/) |  |
+| ✅ OK | 200 | **r-packaging.json**<br>(`r-packaging.json`) | [Link](https://carpentries-incubator.github.io/lesson-R-packaging/) |  |
+| ✅ OK | 200 | **reproducible-computational-environments-using-containers.json**<br>(`reproducible-computational-environments-using-containers.json`) | [Link](https://carpentries-incubator.github.io/docker-introduction/) |  |
+| ✅ OK | 200 | **reproducible-research-for-teams-with-github.json**<br>(`reproducible-research-for-teams-with-github.json`) | [Link](https://ucdavisdatalab.github.io/workshop_git_for_teams/chapters/index.html) |  |
+| ✅ OK | 200 | **research-software-engineering-with-python-course.json**<br>(`research-software-engineering-with-python-course.json`) | [Link](https://alan-turing-institute.github.io/rse-course/html/index.html) |  |
+| ✅ OK | 200 | **responsible-data-science.json**<br>(`responsible-data-science.json`) | [Link](https://ucdavisdatalab.github.io/responsible-data-science/) |  |
+| ✅ OK | 200 | **social-coding-and-open-source-collaboration.json**<br>(`social-coding-and-open-source-collaboration.json`) | [Link](https://coderefinery.github.io/social-coding/) |  |
+| ✅ OK | 200 | **spatial-sql-with-spatialite.json**<br>(`spatial-sql-with-spatialite.json`) | [Link](https://ucdavisdatalab.github.io/Spatial_SQL/) |  |
+| ✅ OK | 200 | **starting-an-open-source-project.json**<br>(`starting-an-open-source-project.json`) | [Link](https://opensource.guide/starting-a-project/) |  |
+| ✅ OK | 200 | **testing-and-test-driven-development.json**<br>(`testing-and-test-driven-development.json`) | [Link](https://coderefinery.github.io/testing/) |  |
+| ✅ OK | 200 | **understanding-software-licensing.json**<br>(`understanding-software-licensing.json`) | [Link](https://intersect-training.org/software-licensing/) |  |
+| ✅ OK | 200 | **unit-testing-and-tdd-in-python.json**<br>(`unit-testing-and-tdd-in-python.json`) | [Link](https://intersect-training.org/testing/instructor/) |  |
+| ✅ OK | 200 | **writing-documentation-for-software-projects.json**<br>(`writing-documentation-for-software-projects.json`) | [Link](https://intersect-training.org/Documentation/) |  |

--- a/scripts/standardize-oss-roles.mjs
+++ b/scripts/standardize-oss-roles.mjs
@@ -2,23 +2,19 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-// Emulate __dirname in ESM
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-
 const CONTENT_DIR = path.join(__dirname, '../src/content/lessons');
 
-// The single source of truth for allowed roles
 const CANONICAL_ROLES = new Set([
   'Contributor',
   'Maintainer',
   'Community Manager'
 ]);
 
-// Mapping of known non-canonical values to canonical ones
 const ROLE_MAPPING = {
   'Governance': 'Maintainer',
-  'User/Consumer': null // null means drop the value
+  'User/Consumer': null 
 };
 
 async function standardizeOSSRoles() {
@@ -26,44 +22,35 @@ async function standardizeOSSRoles() {
     const files = await fs.readdir(CONTENT_DIR);
     const jsonFiles = files.filter(file => file.endsWith('.json'));
 
-    if (jsonFiles.length === 0) {
-      console.log(`No JSON files found in ${CONTENT_DIR}`);
-      return;
-    }
-
     let updatedFilesCount = 0;
+    
+    // 1. EXPANDED TRACKING
     const flaggedFiles = {
       ip: [],
-      userConsumer: []
+      userConsumer: [],
+      missingRole: [], // Tracks files with no role
+      invalidRole: []  // Tracks files with an unrecognized role
     };
 
     console.log('==================================================');
-    console.log('STANDARDIZING OSS ROLES');
+    console.log('STANDARDIZING & VALIDATING OSS ROLES');
     console.log('==================================================\n');
 
     for (const file of jsonFiles) {
       const filePath = path.join(CONTENT_DIR, file);
       const content = await fs.readFile(filePath, 'utf-8');
       
-      let data;
-      try {
-        data = JSON.parse(content);
-      } catch (parseErr) {
-        console.warn(`⚠️ Warning: Could not parse JSON in ${file}`);
-        continue;
-      }
-
+      let data = JSON.parse(content);
       const originalRole = data.ossRole;
       
-      // Skip files without an ossRole
+      // 2. CATCH MISSING ROLES
       if (!originalRole || typeof originalRole !== 'string' || originalRole.trim() === '') {
+        flaggedFiles.missingRole.push(file);
         continue;
       }
 
-      // Check for flags BEFORE modifying
       if (originalRole.includes('IP')) {
         flaggedFiles.ip.push(file);
-        // We skip modifying this file automatically so you can manually inspect it
         continue; 
       }
 
@@ -71,9 +58,7 @@ async function standardizeOSSRoles() {
         flaggedFiles.userConsumer.push(file);
       }
 
-      // Split by comma, trim, map, and filter
       const parts = originalRole.split(',').map(r => r.trim()).filter(Boolean);
-      
       const newRolesSet = new Set();
       
       for (const part of parts) {
@@ -81,51 +66,63 @@ async function standardizeOSSRoles() {
           newRolesSet.add(part);
         } else if (part in ROLE_MAPPING) {
           const mappedValue = ROLE_MAPPING[part];
-          if (mappedValue !== null) {
-            newRolesSet.add(mappedValue);
-          }
+          if (mappedValue !== null) newRolesSet.add(mappedValue);
         } else {
-          console.warn(`⚠️ Warning: Unrecognized role "${part}" found in ${file}. Leaving as is.`);
+          // 3. CATCH INVALID ROLES
+          flaggedFiles.invalidRole.push({ file, role: part });
           newRolesSet.add(part);
         }
       }
 
-      // Join back to a string
       const newRoleString = Array.from(newRolesSet).join(', ');
 
-      // If changes were made, write to the file
       if (originalRole !== newRoleString) {
         data.ossRole = newRoleString;
-        
-        // Write the updated JSON back to the file with 2-space indentation
         await fs.writeFile(filePath, JSON.stringify(data, null, 2) + '\n', 'utf-8');
-        console.log(`✅ Updated: ${file} ("${originalRole}" -> "${newRoleString}")`);
         updatedFilesCount++;
       }
     }
 
+    // 4. PRINT COMPREHENSIVE REPORT
     console.log('\n==================================================');
     console.log('SUMMARY');
     console.log(`Files successfully updated: ${updatedFilesCount}`);
     
     console.log('\n🚨 REQUIRES MANUAL REVIEW 🚨');
-    if (flaggedFiles.ip.length > 0) {
-      console.log(`\nFound "IP" in the following files (skipped auto-update):`);
-      flaggedFiles.ip.forEach(f => console.log(`  - ${f}`));
-    } else {
-      console.log(`\nNo "IP" files found.`);
+    
+    if (flaggedFiles.missingRole.length > 0) {
+      console.log(`\n❌ MISSING ROLES (${flaggedFiles.missingRole.length} files):`);
+      flaggedFiles.missingRole.forEach(f => console.log(`  - ${f}`));
     }
 
-    if (flaggedFiles.userConsumer.length > 0) {
-      console.log(`\nFound and dropped "User/Consumer" from the following files:`);
-      flaggedFiles.userConsumer.forEach(f => console.log(`  - ${f}`));
+    if (flaggedFiles.invalidRole.length > 0) {
+      console.log(`\n❌ INVALID ROLES (Not canonical or mapped):`);
+      flaggedFiles.invalidRole.forEach(item => console.log(`  - ${item.file}: "${item.role}"`));
     }
+
+    if (flaggedFiles.ip.length > 0) {
+      console.log(`\n⚠️ "IP" FOUND (Skipped auto-update):`);
+      flaggedFiles.ip.forEach(f => console.log(`  - ${f}`));
+    }
+
+    // 5. EXIT WITH ERROR CODE IF BAD DATA EXISTS (Crucial for scaling/CI)
+    const hasErrors = flaggedFiles.missingRole.length > 0 || flaggedFiles.invalidRole.length > 0 || flaggedFiles.ip.length > 0;
     
-    console.log('==================================================');
+    if (hasErrors) {
+      console.log('\n==================================================');
+      console.error('Script finished with validation errors. Please fix the flagged files above.');
+      process.exit(1); // Tells the terminal/CI pipeline that this script failed
+    } else {
+      console.log('\nAll roles are valid and standardized! 🎉');
+      process.exit(0);
+    }
 
   } catch (err) {
-    console.error('❌ Error processing the content directory:', err.message);
+    console.error('❌ Error:', err.message);
+    process.exit(1);
   }
 }
+
+standardizeOSSRoles();
 
 standardizeOSSRoles();

--- a/scripts/standardize-oss-roles.mjs
+++ b/scripts/standardize-oss-roles.mjs
@@ -1,0 +1,131 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Emulate __dirname in ESM
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const CONTENT_DIR = path.join(__dirname, '../src/content/lessons');
+
+// The single source of truth for allowed roles
+const CANONICAL_ROLES = new Set([
+  'Contributor',
+  'Maintainer',
+  'Community Manager'
+]);
+
+// Mapping of known non-canonical values to canonical ones
+const ROLE_MAPPING = {
+  'Governance': 'Maintainer',
+  'User/Consumer': null // null means drop the value
+};
+
+async function standardizeOSSRoles() {
+  try {
+    const files = await fs.readdir(CONTENT_DIR);
+    const jsonFiles = files.filter(file => file.endsWith('.json'));
+
+    if (jsonFiles.length === 0) {
+      console.log(`No JSON files found in ${CONTENT_DIR}`);
+      return;
+    }
+
+    let updatedFilesCount = 0;
+    const flaggedFiles = {
+      ip: [],
+      userConsumer: []
+    };
+
+    console.log('==================================================');
+    console.log('STANDARDIZING OSS ROLES');
+    console.log('==================================================\n');
+
+    for (const file of jsonFiles) {
+      const filePath = path.join(CONTENT_DIR, file);
+      const content = await fs.readFile(filePath, 'utf-8');
+      
+      let data;
+      try {
+        data = JSON.parse(content);
+      } catch (parseErr) {
+        console.warn(`⚠️ Warning: Could not parse JSON in ${file}`);
+        continue;
+      }
+
+      const originalRole = data.ossRole;
+      
+      // Skip files without an ossRole
+      if (!originalRole || typeof originalRole !== 'string' || originalRole.trim() === '') {
+        continue;
+      }
+
+      // Check for flags BEFORE modifying
+      if (originalRole.includes('IP')) {
+        flaggedFiles.ip.push(file);
+        // We skip modifying this file automatically so you can manually inspect it
+        continue; 
+      }
+
+      if (originalRole.includes('User/Consumer')) {
+        flaggedFiles.userConsumer.push(file);
+      }
+
+      // Split by comma, trim, map, and filter
+      const parts = originalRole.split(',').map(r => r.trim()).filter(Boolean);
+      
+      const newRolesSet = new Set();
+      
+      for (const part of parts) {
+        if (CANONICAL_ROLES.has(part)) {
+          newRolesSet.add(part);
+        } else if (part in ROLE_MAPPING) {
+          const mappedValue = ROLE_MAPPING[part];
+          if (mappedValue !== null) {
+            newRolesSet.add(mappedValue);
+          }
+        } else {
+          console.warn(`⚠️ Warning: Unrecognized role "${part}" found in ${file}. Leaving as is.`);
+          newRolesSet.add(part);
+        }
+      }
+
+      // Join back to a string
+      const newRoleString = Array.from(newRolesSet).join(', ');
+
+      // If changes were made, write to the file
+      if (originalRole !== newRoleString) {
+        data.ossRole = newRoleString;
+        
+        // Write the updated JSON back to the file with 2-space indentation
+        await fs.writeFile(filePath, JSON.stringify(data, null, 2) + '\n', 'utf-8');
+        console.log(`✅ Updated: ${file} ("${originalRole}" -> "${newRoleString}")`);
+        updatedFilesCount++;
+      }
+    }
+
+    console.log('\n==================================================');
+    console.log('SUMMARY');
+    console.log(`Files successfully updated: ${updatedFilesCount}`);
+    
+    console.log('\n🚨 REQUIRES MANUAL REVIEW 🚨');
+    if (flaggedFiles.ip.length > 0) {
+      console.log(`\nFound "IP" in the following files (skipped auto-update):`);
+      flaggedFiles.ip.forEach(f => console.log(`  - ${f}`));
+    } else {
+      console.log(`\nNo "IP" files found.`);
+    }
+
+    if (flaggedFiles.userConsumer.length > 0) {
+      console.log(`\nFound and dropped "User/Consumer" from the following files:`);
+      flaggedFiles.userConsumer.forEach(f => console.log(`  - ${f}`));
+    }
+    
+    console.log('==================================================');
+
+  } catch (err) {
+    console.error('❌ Error processing the content directory:', err.message);
+  }
+}
+
+standardizeOSSRoles();

--- a/src/content/lessons/building-community.json
+++ b/src/content/lessons/building-community.json
@@ -11,7 +11,7 @@
   "learningResourceType": "Guide",
   "author": "GitHub",
   "license": "CC-BY-4.0",
-  "ossRole": "Community Manager, Governance",
+  "ossRole": "Community Manager, Maintainer",
   "inLanguage": [
     "English",
     "Bulgarian/Български",

--- a/src/content/lessons/finding-users-for-your-project.json
+++ b/src/content/lessons/finding-users-for-your-project.json
@@ -11,7 +11,7 @@
   "learningResourceType": "Guide",
   "author": "GitHub",
   "license": "CC-BY-4.0",
-  "ossRole": "Community Manager, User/Consumer",
+  "ossRole": "Community Manager",
   "inLanguage": [
     "English",
     "Persian/Farsi",


### PR DESCRIPTION
- wrote scripts/audit-oss-roles.mjs (to run: node scripts/audit-oss-roles.mjs) which outputs list of unique raw strings of ossRoles (comma separated), unique individual terms, and a summary of read JSON files, missing ossRoles inputs, total unique raw strings, and total unique individual terms
-  wrote scripts/metadata-report.mjs which outputs a markdown file (metadata-report.md) to scripts/output/
- wrote script/standardize-oss-roles.mjs which maps canonical roles and flags specific ossRoles (IP)
- wrote scripts/check-lesson-urls.mjs and check-urls.yml which outputs a markdown file (url-report.md) ordered as dead --> redirecting --> ok links and the github actions workflow runs weekly Monday

Tackles issues: 71, 73