### PR TITLE
ci: implement soft-fail for external URL checks

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -51,7 +51,8 @@ jobs:
           git diff --name-only "origin/${{ github.base_ref }}...HEAD" > .github/changed-files.txt
           npm run validate:lessons -- \
             --changed-files .github/changed-files.txt \
-            --report-json .github/lesson-validation-report.json
+            --report-json .github/lesson-validation-report.json \
+            --soft-fail-external
 
       - name: Run Astro check
         run: npx astro check

--- a/scripts/validate-lessons.js
+++ b/scripts/validate-lessons.js
@@ -317,6 +317,7 @@ async function loadValidLearnerCategories() {
 async function validate() {
   const args = parseArgs(process.argv.slice(2));
   const reportJsonPath = args['report-json'] ? path.resolve(process.cwd(), String(args['report-json'])) : null;
+  const softFailExternal = !!args['soft-fail-external'];
   const changedFiles = await resolveChangedFiles(args['changed-files']);
   const urlTimeoutMs = parseIntegerOption('url-timeout-ms', args['url-timeout-ms'], DEFAULT_URL_TIMEOUT_MS);
   const urlRetries = parseIntegerOption('url-retries', args['url-retries'], DEFAULT_URL_RETRIES);
@@ -526,7 +527,8 @@ async function validate() {
       addRuleViolation(
         'broken-url',
         entry.lesson,
-        `URL check failed with HTTP ${result.statusCode} (${entry.url})`
+        `URL check failed with HTTP ${result.statusCode} (${entry.url})`,
+        { warningOnly: softFailExternal }
       );
     } else if (result.outcome === 'transient-failure') {
       addRuleViolation(


### PR DESCRIPTION
This PR implements a tiered validation model for lesson URLs.

### Changes:
- Modified `scripts/validate-lessons.js` to support a `--soft-fail-external` flag.
- When this flag is used, external 404/500 errors are treated as **warnings** rather than **blocking errors**.
- Structural errors (missing fields, duplicate slugs, invalid syntax) remain **blocking errors**.
- Updated `pr-check.yml` to use this flag.

### Why:
Prevents 'build flakiness' where PRs are blocked by third-party website downtime. We still have a weekly scheduled audit that tracks these as the source of truth for link health.