### PR TITLE
feat: implement Browse All Lessons CTA panel on homepage

### DIFF
--- a/src/components/home/BrowseAllLessonsPanel.astro
+++ b/src/components/home/BrowseAllLessonsPanel.astro
@@ -1,7 +1,11 @@
 <div class="home-browse-panel">
   <div class="home-browse-panel__inner">
+    <p class="home-browse-panel__tagline">Explore the complete open source lesson library</p>
     <a href={`${import.meta.env.BASE_URL}lessons`} class="home-browse-panel__button">
       Browse All Lessons
+      <svg class="home-browse-panel__button-icon" aria-hidden="true" width="16" height="16" viewBox="0 0 16 16" fill="none">
+        <path d="M3 8h10M9 4l4 4-4 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
     </a>
   </div>
 </div>

--- a/src/components/home/home.css
+++ b/src/components/home/home.css
@@ -399,40 +399,62 @@
   box-shadow: 0 6px 18px rgba(18, 24, 33, 0.06);
 }
 
-/* Remove the broken pseudo-element */
 .home-browse-panel::before {
   content: none;
 }
 
 .home-browse-panel__inner {
   display: flex;
+  flex-direction: column;
   min-height: 13rem;
   align-items: center;
   justify-content: center;
-  padding: 2rem;
+  gap: 1.5rem;
+  padding: 3rem 2rem;
+}
+
+.home-browse-panel__tagline {
+  margin: 0;
+  font-family: var(--font-sans);
+  font-size: clamp(1rem, 1.6vw, 1.2rem);
+  font-weight: 600;
+  line-height: 1.15;
+  letter-spacing: -0.035em;
+  text-transform: uppercase;
+  color: var(--text-primary);
+  text-align: center;
 }
 
 .home-browse-panel__button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 1rem 1.9rem;
+  gap: 0.55rem;
+  padding: 0.875rem 2rem;
   border-radius: var(--radius-pill);
-  background: color-mix(in srgb, var(--bg-surface-strong) 82%, var(--bg-surface) 18%);
-  color: var(--text-primary);
-  font-size: 1rem;
+  background: var(--uc-blue);
+  color: var(--uc-white);
+  font-family: var(--font-sans);
+  font-size: var(--font-size-base);
   font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.01em;
+  letter-spacing: 0.04em;
   text-decoration: none;
-  border: 1px solid var(--border-light);
-  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  border: none;
+  box-shadow: 0 4px 14px rgba(0, 114, 163, 0.22);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
 }
 
 .home-browse-panel__button:hover {
+  color: var(--uc-white);
+  text-decoration: none;
   transform: translateY(-2px);
-  background: var(--bg-surface);
-  box-shadow: 0 12px 20px rgba(18, 24, 33, 0.12);
+  background-color: var(--uc-dark-blue);
+  box-shadow: 0 8px 24px rgba(0, 114, 163, 0.38);
+}
+
+.home-browse-panel__button-icon {
+  flex-shrink: 0;
 }
 
 @media (max-width: 960px) {
@@ -475,6 +497,8 @@
   }
 
   .home-browse-panel__inner {
-    min-height: 9.5rem;
+    min-height: 10rem;
+    gap: 1.25rem;
+    padding: 2.25rem 1.5rem;
   }
 }


### PR DESCRIPTION
Extends BrowseAllLessonsPanel with a centered tagline and pill-shaped UC-blue CTA button with arrow icon, styled using shared radius/typography tokens and adaptive theme tokens to match the rounded CategoryPanel stack.