### PR TITLE
feat(deploy): configure subdomain deployment at education.ucospo.net

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,10 +7,9 @@ import keystatic from '@keystatic/astro';
 const isDev = !process.argv.some(arg => arg === 'build' || arg.includes('build'));
 
 export default defineConfig({
-  site: 'https://UC-OSPO-Network.github.io',
-  // Align local dev with GitHub Pages (served under /education).
+  site: 'https://education.ucospo.net',
   // Keystatic requires root access in dev mode for its API to work correctly.
-  base: isDev ? undefined : '/education/',
+  base: isDev ? undefined : '/',
   // Keystatic injects non-prerendered routes, which require a server adapter in production builds.
   // This site deploys as a static build (GitHub Pages), so we only enable Keystatic in dev.
   integrations: [react(), ...(isDev ? [keystatic()] : [])],

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+education.ucospo.net

--- a/src/lib/siteChrome.ts
+++ b/src/lib/siteChrome.ts
@@ -83,7 +83,7 @@ const nav: ChromeNavItem[] = [
       },
       {
         label: "Template Guides",
-        href: "https://ucospo.net/oss-resources",
+        href: "https://ucospo.net/oss-resources/template-guides/readme-guide",
         external: true,
       },
     ],


### PR DESCRIPTION
## Summary
- Updates `site` URL to `https://education.ucospo.net` and base path to `/` for custom domain routing
- Adds `public/CNAME` file for GitHub Pages custom domain support
- Fixes placeholder Template Guides nav link in `siteChrome.ts`

Supersedes #36 (stale since January, rebased past too many breaking changes to recover).

## Maintainer action required before merging

1. Add DNS CNAME record: `education → UC-OSPO-Network.github.io`
2. After DNS propagates, go to repo Settings → Pages → set custom domain to `education.ucospo.net`
3. Enable **Enforce HTTPS**

## Test plan
- [ ] DNS CNAME record added
- [ ] `npm run build` passes locally
- [ ] CI passes
- [ ] Site loads at `https://education.ucospo.net` after DNS propagation

🤖 Generated with [Claude Code](https://claude.com/claude-code)