### PR TITLE
Add layered Playwright accessibility flow checks

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -41,5 +41,18 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
       - name: Run accessibility check
+        if: github.event_name == 'pull_request'
         run: npm run check-a11y
+
+      - name: Run accessibility flow check
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        run: npm run check-a11y:flows
+
+      - name: Run full accessibility check
+        if: github.event_name != 'pull_request'
+        run: npm run check-a11y:all

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -69,6 +69,13 @@ jobs:
       - name: Check accessibility
         run: npm run check-a11y
 
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Check accessibility flows
+        continue-on-error: true
+        run: npm run check-a11y:flows
+
       # ============================================
       # Step 6: Report lesson validation
       # ============================================

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
+playwright-report/
+test-results/
 
 # Environment variables
 .env

--- a/README.md
+++ b/README.md
@@ -62,23 +62,24 @@ These checks run automatically on pull requests via GitHub Actions.
 ### Accessibility Scanning
 
 The repository now includes an accessibility workflow at `.github/workflows/accessibility.yml`.
-It runs the repo's local Puppeteer + axe accessibility audit in GitHub Actions against a production-shaped `/education/` preview of the built site.
+It runs layered accessibility checks against a production-shaped `/education/` preview of the built site.
 
-- Runs automatically on pull requests that change site code, every Monday at 14:00 UTC, and manually from the Actions tab
-- Uploads the generated JSON audit report as a workflow artifact
-- Publishes a per-page violation summary to the workflow job summary
-- Supports optional CI gating through the `A11Y_FAIL_ERRORS_COUNT` repository variable
+- `npm run check-a11y` builds the static site, serves it locally under `/education/`, generates a sitemap, and runs `pa11y-ci` against every built page with WCAG 2.1 AA settings.
+- `npm run check-a11y:flows` runs Chromium Playwright tests for keyboard navigation, interactive states, and `@axe-core/playwright` checks after those states are opened.
+- `npm run check-a11y:all` runs both layers.
 
-To turn on blocking CI failures, add a repository variable named `A11Y_FAIL_ERRORS_COUNT` with a value greater than `0`.
-That threshold is passed into the audit script so the team can tune enforcement without another code change.
+Pull requests block on the full-page pa11y scan. Playwright flow checks run on pull requests as a nonblocking rollout step and run as part of the full scheduled/manual accessibility workflow.
 
-For a local approximation of the same flow, run:
+For local checks, run:
 
 ```bash
-npm run a11y:local
+npm run check-a11y
+npm run check-a11y:flows
+npm run check-a11y:all
 ```
 
-That command builds the site, serves the generated files under `/education/`, and runs the repo's Puppeteer + axe audit against the local preview. If port `4321` is already in use, set `A11Y_PORT` first, for example `A11Y_PORT=4322 npm run a11y:local`.
+If port `4321` is already in use, set `A11Y_PORT` first, for example `A11Y_PORT=4322 npm run check-a11y`.
+See `docs/ACCESSIBILITY_GUIDE.md` and `docs/SCREEN_READER_QA_CHECKLIST.md` for contributor guidance and manual release checks.
 
 ### Run Locally
 

--- a/docs/ACCESSIBILITY_GUIDE.md
+++ b/docs/ACCESSIBILITY_GUIDE.md
@@ -1,0 +1,56 @@
+# Accessibility Guide
+
+This project targets WCAG 2.1 AA for site UI and lesson browsing workflows. Automated checks help catch regressions, but contributors should still design and review changes with keyboard and screen-reader users in mind.
+
+## Local Checks
+
+Run the broad page scan:
+
+```bash
+npm run check-a11y
+```
+
+Run keyboard and interaction flows:
+
+```bash
+npm run check-a11y:flows
+```
+
+Run both layers:
+
+```bash
+npm run check-a11y:all
+```
+
+If port `4321` is already in use, choose another local port:
+
+```bash
+A11Y_PORT=4322 npm run check-a11y:all
+```
+
+## Contributor Expectations
+
+- Use semantic HTML before ARIA. Prefer native links, buttons, headings, lists, form controls, and landmarks.
+- Keep exactly one page-level `h1`; do not skip heading levels for visual sizing.
+- Give every form control a visible or programmatic label.
+- Ensure all interactive controls work with keyboard only.
+- Preserve visible focus states and logical tab order.
+- Use link and button text that makes sense out of context.
+- Keep text and UI contrast at WCAG 2.1 AA levels.
+- Avoid hover-only interactions; support focus and touch equivalents.
+- Keep landmarks clear: header/navigation/main/footer should remain understandable in assistive technology.
+
+## When To Add Playwright Flow Coverage
+
+Add or update `tests/a11y/flows.spec.ts` when a change introduces:
+
+- A new menu, disclosure, modal, filter, tab, or other interactive state.
+- Keyboard behavior that must open, close, move focus, or preserve focus.
+- A page-level workflow that pa11y cannot reach from the static loaded page.
+- ARIA state changes such as `aria-expanded`, `aria-controls`, or dynamic result counts.
+
+Use `@axe-core/playwright` after opening interactive states so the tested DOM matches what users actually encounter.
+
+## Manual Review
+
+Automated checks do not prove that a screen-reader experience is understandable. Use `docs/SCREEN_READER_QA_CHECKLIST.md` for release-level manual checks, especially after navigation, filtering, layout, or content-template changes.

--- a/docs/SCREEN_READER_QA_CHECKLIST.md
+++ b/docs/SCREEN_READER_QA_CHECKLIST.md
@@ -1,0 +1,55 @@
+# Screen Reader QA Checklist
+
+Use this checklist for release-level confidence. VoiceOver on macOS is the default local pass; NVDA on Windows is recommended when a release changes navigation, filtering, or page templates.
+
+## Setup
+
+- Build and preview the site, or use a deployed preview that serves the site under `/education/`.
+- Run `npm run check-a11y:all` first so manual time focuses on experience quality.
+- Test with keyboard only before turning on the screen reader.
+
+## VoiceOver Quick Commands
+
+- Start or stop VoiceOver: `Command + F5`
+- Move to next item: `Control + Option + Right Arrow`
+- Move to previous item: `Control + Option + Left Arrow`
+- Activate current item: `Control + Option + Space`
+- Open rotor: `Control + Option + U`
+
+## Core Pages
+
+Check:
+
+- `/education/`
+- `/education/lessons/`
+- One lesson detail page, such as `/education/lessons/introduction-to-git/`
+- `/education/pathways/`
+- One pathway detail page, such as `/education/pathways/getting-started/`
+- `/education/develop-a-lesson/`
+- `/education/for-educators/`
+
+## Required Checks
+
+- Page title and first heading clearly identify the page.
+- Landmarks expose useful regions, especially primary navigation and main content.
+- The skip link appears on first Tab and moves users to main content.
+- Heading navigation follows a logical order.
+- Primary navigation can be opened and closed by keyboard.
+- Dropdown/menu buttons announce expanded or collapsed state.
+- Links and buttons have useful accessible names.
+- Lesson filter fields are announced with labels.
+- Typing in lesson search updates results without losing usable focus.
+- Clear Filters is reachable, understandable, and resets the results.
+- Lesson detail pages read in a sensible order from title through metadata and body sections.
+- Pathway pages read in a sensible order from title through lesson groups.
+- Focus never gets trapped in navigation, filters, or page content.
+- Decorative icons or images are not announced as noisy content.
+
+## Record Results
+
+For release notes or PR comments, record:
+
+- Screen reader and browser used.
+- Pages checked.
+- Any blockers found.
+- Any follow-up issues opened.

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,8 @@
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.6",
+        "@axe-core/playwright": "^4.11.0",
+        "@playwright/test": "^1.56.1",
         "@types/papaparse": "^5.5.2",
         "pa11y": "^9.0.1",
         "pa11y-ci": "^4.0.1",
@@ -211,6 +213,19 @@
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.5.0"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmmirror.com/@axe-core/playwright/-/playwright-4.11.3.tgz",
+      "integrity": "sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.4"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2048,6 +2063,22 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmmirror.com/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@puppeteer/browsers": {
@@ -4909,9 +4940,9 @@
       "license": "MIT"
     },
     "node_modules/axe-core": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmmirror.com/axe-core/-/axe-core-4.11.1.tgz",
-      "integrity": "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==",
+      "version": "4.11.4",
+      "resolved": "https://registry.npmmirror.com/axe-core/-/axe-core-4.11.4.tgz",
+      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
       "dev": true,
       "license": "MPL-2.0",
       "engines": {
@@ -9104,6 +9135,54 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmmirror.com/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmmirror.com/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmmirror.com/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "normalize:lessons": "node scripts/normalize-lessons.js",
     "audit:diff": "node scripts/audit-sheet-json-diff.js",
     "check-a11y": "node scripts/accessibility/run-local-a11y.mjs",
+    "check-a11y:flows": "playwright test",
+    "check-a11y:all": "npm run check-a11y && npm run check-a11y:flows",
     "a11y:local": "npm run check-a11y",
     "audit:oss-roles": "node scripts/audit-oss-roles.mjs",
     "standardize:oss-roles": "node scripts/standardize-oss-roles.mjs",
@@ -43,6 +45,8 @@
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.6",
+    "@axe-core/playwright": "^4.11.0",
+    "@playwright/test": "^1.56.1",
     "@types/papaparse": "^5.5.2",
     "pa11y": "^9.0.1",
     "pa11y-ci": "^4.0.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const port = Number.parseInt(process.env.A11Y_PORT || "4321", 10);
+
+export default defineConfig({
+  testDir: "./tests/a11y",
+  timeout: 30_000,
+  expect: {
+    timeout: 5_000,
+  },
+  reporter: [["list"], ["html", { open: "never" }]],
+  use: {
+    baseURL: `http://127.0.0.1:${port}/education/`,
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "node scripts/accessibility/serve-local-preview.mjs",
+    url: `http://127.0.0.1:${port}/education/`,
+    reuseExistingServer: false,
+    timeout: 120_000,
+  },
+});

--- a/public/styles.css
+++ b/public/styles.css
@@ -314,7 +314,7 @@ summary:focus-visible {
   z-index: 1000;
   padding: 0.7rem 1rem;
   border-radius: var(--radius-sm);
-  background: var(--uc-gold);
+  background: var(--uc-light-gold);
   color: #1a1a1a;
   font-weight: 700;
 }

--- a/scripts/accessibility/local-preview.mjs
+++ b/scripts/accessibility/local-preview.mjs
@@ -1,0 +1,216 @@
+import { spawn } from 'node:child_process';
+import { createReadStream } from 'node:fs';
+import { access, cp, mkdtemp, mkdir, readdir, rm, stat, writeFile } from 'node:fs/promises';
+import { createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { pipeline } from 'node:stream/promises';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export const repoRoot = path.resolve(__dirname, '..', '..');
+export const port = Number.parseInt(process.env.A11Y_PORT || '4321', 10);
+export const baseUrl = `http://127.0.0.1:${port}/education`;
+
+const contentTypes = {
+  '.css': 'text/css; charset=utf-8',
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.svg': 'image/svg+xml',
+  '.webp': 'image/webp',
+  '.ico': 'image/x-icon',
+  '.txt': 'text/plain; charset=utf-8',
+  '.xml': 'application/xml; charset=utf-8',
+  '.woff2': 'font/woff2',
+};
+
+export function runCommand(command, args, extraEnv = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: repoRoot,
+      env: { ...process.env, ...extraEnv },
+      stdio: 'inherit',
+    });
+
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+
+      reject(new Error(`${command} ${args.join(' ')} exited with code ${code}`));
+    });
+  });
+}
+
+async function findIndexPages(dir, root = dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const pages = [];
+
+  for (const entry of entries) {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      pages.push(...(await findIndexPages(entryPath, root)));
+    } else if (entry.isFile() && entry.name === 'index.html') {
+      const relativeDir = path.relative(root, dir).split(path.sep).join('/');
+      const urlPath = relativeDir ? `/education/${relativeDir}/` : '/education/';
+      pages.push(`${baseUrl.replace(/\/$/, '')}${urlPath.replace(/^\/education/, '')}`);
+    }
+  }
+
+  return pages.sort();
+}
+
+async function writeSitemap(previewEducationRoot) {
+  const pageUrls = await findIndexPages(previewEducationRoot);
+  if (pageUrls.length === 0) {
+    throw new Error(`No built pages found under ${previewEducationRoot}`);
+  }
+
+  const sitemap = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    ...pageUrls.map((url) => `  <url><loc>${url}</loc></url>`),
+    '</urlset>',
+    '',
+  ].join('\n');
+
+  await writeFile(path.join(previewEducationRoot, 'sitemap.xml'), sitemap);
+  console.log(`Generated accessibility sitemap with ${pageUrls.length} pages.`);
+}
+
+export async function preparePreview({ build = true } = {}) {
+  if (build) {
+    console.log('Building site for local accessibility audit...');
+    await runCommand('npm', ['run', 'build']);
+  }
+
+  const previewRoot = await mkdtemp(path.join(tmpdir(), 'education-a11y-'));
+  const previewEducationRoot = path.join(previewRoot, 'education');
+
+  console.log('Preparing local preview under /education/ ...');
+  await mkdir(previewEducationRoot, { recursive: true });
+  await cp(path.join(repoRoot, 'dist'), previewEducationRoot, { recursive: true });
+  await access(path.join(previewEducationRoot, 'index.html'));
+  await writeSitemap(previewEducationRoot);
+
+  return {
+    previewRoot,
+    previewEducationRoot,
+    sitemapUrl: `${baseUrl}/sitemap.xml`,
+  };
+}
+
+export async function startStaticServer(previewRoot) {
+  async function resolveFilePath(requestPath) {
+    const normalizedPath = decodeURIComponent(new URL(requestPath, 'http://127.0.0.1').pathname);
+    const candidatePaths = [];
+
+    if (normalizedPath === '/' || normalizedPath === '') {
+      candidatePaths.push(path.join(previewRoot, 'index.html'));
+    }
+
+    const absolutePath = path.resolve(previewRoot, `.${normalizedPath}`);
+    if (!absolutePath.startsWith(previewRoot)) {
+      return null;
+    }
+
+    candidatePaths.push(absolutePath);
+
+    if (!path.extname(absolutePath)) {
+      candidatePaths.push(path.join(absolutePath, 'index.html'));
+      candidatePaths.push(`${absolutePath}.html`);
+    }
+
+    for (const candidate of candidatePaths) {
+      try {
+        const fileStats = await stat(candidate);
+        if (fileStats.isFile()) {
+          return candidate;
+        }
+      } catch {
+        // Keep checking fallback candidates.
+      }
+    }
+
+    return null;
+  }
+
+  const server = createServer(async (req, res) => {
+    try {
+      const filePath = await resolveFilePath(req.url || '/');
+      if (!filePath) {
+        res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+        res.end('Not found');
+        return;
+      }
+
+      const ext = path.extname(filePath).toLowerCase();
+      res.writeHead(200, {
+        'Content-Type': contentTypes[ext] || 'application/octet-stream',
+      });
+      await pipeline(createReadStream(filePath), res);
+    } catch (error) {
+      if (!res.headersSent) {
+        res.writeHead(500, { 'Content-Type': 'text/plain; charset=utf-8' });
+        res.end(`Server error: ${error.message}`);
+        return;
+      }
+
+      res.destroy(error);
+    }
+  });
+
+  await new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, '127.0.0.1', () => {
+      server.removeListener('error', reject);
+      resolve();
+    });
+  });
+
+  return server;
+}
+
+export async function waitForServer() {
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    try {
+      const response = await fetch(`${baseUrl}/`);
+      if (response.ok) {
+        return;
+      }
+    } catch {
+      // Retry until the server is listening.
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+
+  throw new Error(`Timed out waiting for local preview server at ${baseUrl}/`);
+}
+
+export async function closeServer(server) {
+  if (!server) return;
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+export async function cleanupPreview(previewRoot) {
+  if (!previewRoot) return;
+  await rm(previewRoot, { recursive: true, force: true });
+}

--- a/scripts/accessibility/run-local-a11y.mjs
+++ b/scripts/accessibility/run-local-a11y.mjs
@@ -1,20 +1,15 @@
-import { spawn } from 'node:child_process';
-import { createReadStream } from 'node:fs';
-import { access, cp, mkdtemp, mkdir, readdir, rm, stat, writeFile } from 'node:fs/promises';
-import { createServer } from 'node:http';
-import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { pipeline } from 'node:stream/promises';
-import { fileURLToPath } from 'node:url';
+import {
+  baseUrl,
+  cleanupPreview,
+  closeServer,
+  preparePreview,
+  repoRoot,
+  runCommand,
+  startStaticServer,
+  waitForServer,
+} from './local-preview.mjs';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const repoRoot = path.resolve(__dirname, '..', '..');
-const port = Number.parseInt(process.env.A11Y_PORT || '4321', 10);
-const baseUrl = `http://127.0.0.1:${port}/education`;
-const previewRoot = await mkdtemp(path.join(tmpdir(), 'education-a11y-'));
-const previewEducationRoot = path.join(previewRoot, 'education');
-const sitemapPath = path.join(previewEducationRoot, 'sitemap.xml');
 const pa11yBinary = path.join(
   repoRoot,
   'node_modules',
@@ -22,203 +17,28 @@ const pa11yBinary = path.join(
   process.platform === 'win32' ? 'pa11y-ci.cmd' : 'pa11y-ci',
 );
 
-const contentTypes = {
-  '.css': 'text/css; charset=utf-8',
-  '.html': 'text/html; charset=utf-8',
-  '.js': 'application/javascript; charset=utf-8',
-  '.json': 'application/json; charset=utf-8',
-  '.png': 'image/png',
-  '.jpg': 'image/jpeg',
-  '.jpeg': 'image/jpeg',
-  '.svg': 'image/svg+xml',
-  '.webp': 'image/webp',
-  '.ico': 'image/x-icon',
-  '.txt': 'text/plain; charset=utf-8',
-  '.xml': 'application/xml; charset=utf-8',
-};
-
-function runCommand(command, args, extraEnv = {}) {
-  return new Promise((resolve, reject) => {
-    const child = spawn(command, args, {
-      cwd: repoRoot,
-      env: { ...process.env, ...extraEnv },
-      stdio: 'inherit',
-    });
-
-    child.on('error', reject);
-    child.on('exit', (code) => {
-      if (code === 0) {
-        resolve();
-        return;
-      }
-
-      reject(new Error(`${command} ${args.join(' ')} exited with code ${code}`));
-    });
-  });
-}
-
-async function findIndexPages(dir, root = dir) {
-  const entries = await readdir(dir, { withFileTypes: true });
-  const pages = [];
-
-  for (const entry of entries) {
-    const entryPath = path.join(dir, entry.name);
-    if (entry.isDirectory()) {
-      pages.push(...(await findIndexPages(entryPath, root)));
-    } else if (entry.isFile() && entry.name === 'index.html') {
-      const relativeDir = path.relative(root, dir).split(path.sep).join('/');
-      const urlPath = relativeDir ? `/education/${relativeDir}/` : '/education/';
-      pages.push(`${baseUrl.replace(/\/$/, '')}${urlPath.replace(/^\/education/, '')}`);
-    }
-  }
-
-  return pages.sort();
-}
-
-async function writeSitemap() {
-  const pageUrls = await findIndexPages(previewEducationRoot);
-  if (pageUrls.length === 0) {
-    throw new Error(`No built pages found under ${previewEducationRoot}`);
-  }
-
-  const sitemap = [
-    '<?xml version="1.0" encoding="UTF-8"?>',
-    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
-    ...pageUrls.map((url) => `  <url><loc>${url}</loc></url>`),
-    '</urlset>',
-    '',
-  ].join('\n');
-
-  await writeFile(sitemapPath, sitemap);
-  console.log(`Generated accessibility sitemap with ${pageUrls.length} pages.`);
-}
-
-async function resolveFilePath(requestPath) {
-  const normalizedPath = decodeURIComponent(new URL(requestPath, 'http://127.0.0.1').pathname);
-  const candidatePaths = [];
-
-  if (normalizedPath === '/' || normalizedPath === '') {
-    candidatePaths.push(path.join(previewRoot, 'index.html'));
-  }
-
-  const absolutePath = path.resolve(previewRoot, `.${normalizedPath}`);
-  if (!absolutePath.startsWith(previewRoot)) {
-    return null;
-  }
-
-  candidatePaths.push(absolutePath);
-
-  if (!path.extname(absolutePath)) {
-    candidatePaths.push(path.join(absolutePath, 'index.html'));
-    candidatePaths.push(`${absolutePath}.html`);
-  }
-
-  for (const candidate of candidatePaths) {
-    try {
-      const fileStats = await stat(candidate);
-      if (fileStats.isFile()) {
-        return candidate;
-      }
-    } catch {
-      // Keep checking fallback candidates.
-    }
-  }
-
-  return null;
-}
-
-async function startStaticServer() {
-  const server = createServer(async (req, res) => {
-    try {
-      const filePath = await resolveFilePath(req.url || '/');
-      if (!filePath) {
-        res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
-        res.end('Not found');
-        return;
-      }
-
-      const ext = path.extname(filePath).toLowerCase();
-      res.writeHead(200, {
-        'Content-Type': contentTypes[ext] || 'application/octet-stream',
-      });
-      await pipeline(createReadStream(filePath), res);
-    } catch (error) {
-      if (!res.headersSent) {
-        res.writeHead(500, { 'Content-Type': 'text/plain; charset=utf-8' });
-        res.end(`Server error: ${error.message}`);
-        return;
-      }
-
-      res.destroy(error);
-    }
-  });
-
-  await new Promise((resolve, reject) => {
-    server.once('error', reject);
-    server.listen(port, '127.0.0.1', () => {
-      server.removeListener('error', reject);
-      resolve();
-    });
-  });
-
-  return server;
-}
-
-async function waitForServer() {
-  for (let attempt = 0; attempt < 30; attempt += 1) {
-    try {
-      const response = await fetch(`${baseUrl}/`);
-      if (response.ok) {
-        return;
-      }
-    } catch {
-      // Retry until the server is listening.
-    }
-
-    await new Promise((resolve) => setTimeout(resolve, 250));
-  }
-
-  throw new Error(`Timed out waiting for local preview server at ${baseUrl}/`);
-}
-
-console.log('Building site for local accessibility audit...');
-await runCommand('npm', ['run', 'build']);
-
-console.log('Preparing local preview under /education/ ...');
-await mkdir(previewEducationRoot, { recursive: true });
-await cp(path.join(repoRoot, 'dist'), previewEducationRoot, { recursive: true });
-await access(path.join(previewEducationRoot, 'index.html'));
-await writeSitemap();
-
+let preview;
 let server;
+
 try {
+  preview = await preparePreview();
+
   console.log(`Starting local preview server on ${baseUrl}/ ...`);
-  server = await startStaticServer();
+  server = await startStaticServer(preview.previewRoot);
   await waitForServer();
 
   console.log('Running pa11y-ci accessibility audit...');
   await runCommand(pa11yBinary, [
     '--sitemap',
-    `${baseUrl}/sitemap.xml`,
+    preview.sitemapUrl,
     '--sitemap-find',
     'http://127.0.0.1:[0-9]+',
     '--sitemap-replace',
-    `http://127.0.0.1:${port}`,
+    `http://127.0.0.1:${new URL(baseUrl).port}`,
   ]);
 
   console.log('Local accessibility audit complete.');
 } finally {
-  if (server) {
-    await new Promise((resolve, reject) => {
-      server.close((error) => {
-        if (error) {
-          reject(error);
-          return;
-        }
-        resolve();
-      });
-    });
-  }
-
-  await rm(previewRoot, { recursive: true, force: true });
+  await closeServer(server);
+  await cleanupPreview(preview?.previewRoot);
 }

--- a/scripts/accessibility/serve-local-preview.mjs
+++ b/scripts/accessibility/serve-local-preview.mjs
@@ -1,0 +1,47 @@
+import {
+  baseUrl,
+  cleanupPreview,
+  closeServer,
+  preparePreview,
+  startStaticServer,
+  waitForServer,
+} from './local-preview.mjs';
+
+let preview;
+let server;
+let isShuttingDown = false;
+
+async function shutdown(exitCode = 0) {
+  if (isShuttingDown) return;
+  isShuttingDown = true;
+
+  await closeServer(server);
+  await cleanupPreview(preview?.previewRoot);
+  process.exit(exitCode);
+}
+
+process.on('SIGINT', () => {
+  shutdown(0).catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+});
+
+process.on('SIGTERM', () => {
+  shutdown(0).catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+});
+
+try {
+  preview = await preparePreview();
+  console.log(`Starting local preview server on ${baseUrl}/ ...`);
+  server = await startStaticServer(preview.previewRoot);
+  await waitForServer();
+  console.log(`Local accessibility preview ready at ${baseUrl}/`);
+} catch (error) {
+  console.error(error);
+  await cleanupPreview(preview?.previewRoot);
+  process.exit(1);
+}

--- a/src/components/lessons/lessons.css
+++ b/src/components/lessons/lessons.css
@@ -201,7 +201,6 @@
   text-transform: uppercase;
   letter-spacing: 0.05em;
   color: var(--text-secondary);
-  opacity: 0.82;
 }
 
 /* Body */

--- a/tests/a11y/flows.spec.ts
+++ b/tests/a11y/flows.spec.ts
@@ -1,0 +1,104 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test, type Page } from "@playwright/test";
+
+async function gotoEducation(page: Page, path = "./") {
+  await page.goto(path);
+  await expect(page.getByRole("main")).toBeVisible();
+}
+
+async function expectNoAxeViolations(page: Page) {
+  const results = await new AxeBuilder({ page })
+    .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
+    .analyze();
+  expect(results.violations).toEqual([]);
+}
+
+test.describe("accessibility page structure", () => {
+  const pages = [
+    { path: "./", heading: /open source learning pathways/i },
+    { path: "./lessons/", heading: /all lessons/i },
+    { path: "./lessons/introduction-to-git/", heading: /introduction to git/i },
+    { path: "./pathways/", heading: /learning pathways/i },
+    { path: "./pathways/getting-started/", heading: /getting started/i },
+  ];
+
+  for (const pageCase of pages) {
+    test(`${pageCase.path} has accessible structure`, async ({ page }) => {
+      await gotoEducation(page, pageCase.path);
+
+      await expect(page.getByRole("main")).toHaveCount(1);
+      await expect(page.getByRole("navigation", { name: /primary/i })).toBeVisible();
+      await expect(page.getByRole("heading", { name: pageCase.heading, level: 1 })).toBeVisible();
+      await expectNoAxeViolations(page);
+    });
+  }
+});
+
+test("keyboard users can skip to main content and operate the desktop nav", async ({ page }) => {
+  await gotoEducation(page);
+
+  await page.keyboard.press("Tab");
+  await expect(page.getByRole("link", { name: /skip to main content/i })).toBeFocused();
+
+  await page.keyboard.press("Enter");
+  await expect(page).toHaveURL(/#main-content$/);
+
+  const educationTrigger = page.getByRole("button", { name: /education/i });
+  await educationTrigger.focus();
+  await page.keyboard.press("Enter");
+  await expect(educationTrigger).toHaveAttribute("aria-expanded", "true");
+  await expect(page.getByRole("navigation", { name: /primary/i }).getByRole("link", { name: "All Lessons" })).toBeVisible();
+  await page.waitForTimeout(250);
+  await expectNoAxeViolations(page);
+
+  await page.keyboard.press("Escape");
+  await expect(educationTrigger).toHaveAttribute("aria-expanded", "false");
+
+  for (let i = 0; i < 8; i += 1) {
+    await page.keyboard.press("Tab");
+    const activeElement = await page.evaluate(() => document.activeElement?.tagName.toLowerCase());
+    expect(activeElement).toMatch(/^(a|button|input|select)$/);
+  }
+});
+
+test("lesson filters are keyboard accessible and keep focus usable", async ({ page }) => {
+  await gotoEducation(page, "./lessons/");
+
+  const count = page.locator(".lessons-filter__count");
+  await expect(count).toContainText(/showing \d+ of \d+ lessons/i);
+  const initialCount = await count.textContent();
+
+  const search = page.getByLabel("Search");
+  await search.focus();
+  await expect(search).toBeFocused();
+  await search.fill("git");
+
+  await expect(count).not.toHaveText(initialCount || "");
+  await expect(search).toBeFocused();
+
+  await page.getByRole("button", { name: /clear filters/i }).first().click();
+  await expect(count).toHaveText(initialCount || "");
+  await expectNoAxeViolations(page);
+});
+
+test("mobile navigation opens, closes, and passes axe in expanded state", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await gotoEducation(page);
+
+  const menuButton = page.getByRole("button", { name: /menu/i });
+  await expect(menuButton).toBeVisible();
+  await menuButton.focus();
+  await page.keyboard.press("Enter");
+  await expect(menuButton).toHaveAttribute("aria-expanded", "true");
+
+  const educationTrigger = page.getByRole("button", { name: /education/i });
+  await educationTrigger.focus();
+  await page.keyboard.press("Enter");
+  await expect(educationTrigger).toHaveAttribute("aria-expanded", "true");
+  await expect(page.getByRole("link", { name: /browse pathways/i })).toBeVisible();
+  await page.waitForTimeout(250);
+  await expectNoAxeViolations(page);
+
+  await page.keyboard.press("Escape");
+  await expect(menuButton).toHaveAttribute("aria-expanded", "false");
+});


### PR DESCRIPTION
## Summary
- Keep `pa11y-ci` as the broad WCAG 2.1 AA gate over every built `/education/` page.
- Add Chromium-only Playwright flow tests with `@axe-core/playwright` for keyboard navigation, nav menus, lesson filters, and other interactive states.
- Share the local production-shaped preview server between pa11y and Playwright so both layers test the same built output.
- Update CI to run the new flow checks, keep them nonblocking during rollout, and document manual screen-reader QA for contributors.
- Fix a few contrast issues uncovered by the new checks.

## Testing
- Local a11y validation passed for both layers: full-page `pa11y-ci` scan and Playwright flow tests.
- Existing build and link validation passed, along with Astro type checking.