### PR TITLE
FEATURE: GitHub community health signals on lesson cards

### DIFF
--- a/.github/workflows/refresh-github-health.yml
+++ b/.github/workflows/refresh-github-health.yml
@@ -1,12 +1,15 @@
-name: Update GitHub Health Snapshot
+name: Refresh GitHub Health Snapshot
 
 on:
   schedule:
-    - cron: '0 6 * * 1'  # Every Monday at 06:00 UTC
+    - cron: '0 6 * * 1'
   workflow_dispatch:
+  push:
+    paths:
+      - 'src/content/lessons/**.json'
 
 jobs:
-  update-health:
+  refresh:
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -26,10 +29,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Commit updated snapshot
+      - name: Commit if changed
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add src/data/github-health.json
-          git diff --cached --quiet || git commit -m "chore: update GitHub health snapshot"
-          git push
+          git diff --quiet src/data/github-health.json || (
+            git add src/data/github-health.json &&
+            git commit -m "chore(data): refresh GitHub health signals [skip ci]" &&
+            git push
+          )

--- a/.github/workflows/staleness-check.yml
+++ b/.github/workflows/staleness-check.yml
@@ -1,0 +1,165 @@
+name: Lesson Staleness Check
+
+on:
+  schedule:
+    - cron: '0 9 1 */3 *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  check-staleness:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for stale lessons and open issues
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+
+            const STALE_MONTHS = 18;
+            const LESSONS_DIR = 'src/content/lessons';
+            const LESSON_SITE_BASE = 'https://ucospo.net/education/lessons';
+            const LABEL = 'stale-lesson';
+            const now = new Date();
+
+            function getLessonSlug(file, lesson) {
+              const fromLesson = typeof lesson.slug === 'string' ? lesson.slug.trim() : '';
+              return fromLesson || file.replace(/\.json$/, '');
+            }
+
+            function parseDate(dateStr) {
+              if (!dateStr || typeof dateStr !== 'string') return null;
+              const trimmed = dateStr.trim();
+              if (!trimmed) return null;
+
+              const isoMatch = /^\d{4}-\d{2}-\d{2}$/.test(trimmed);
+              const date = isoMatch
+                ? new Date(`${trimmed}T00:00:00Z`)
+                : new Date(trimmed);
+
+              return Number.isNaN(date.getTime()) ? null : date;
+            }
+
+            function monthsSince(date) {
+              return (
+                (now.getUTCFullYear() - date.getUTCFullYear()) * 12 +
+                (now.getUTCMonth() - date.getUTCMonth())
+              );
+            }
+
+            function isStale(date) {
+              const monthDiff = monthsSince(date);
+              return monthDiff > STALE_MONTHS ||
+                (monthDiff === STALE_MONTHS && now.getUTCDate() > date.getUTCDate());
+            }
+
+            try {
+              await github.rest.issues.getLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: LABEL,
+              });
+            } catch (error) {
+              if (error.status === 404) {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: LABEL,
+                  color: 'fbca04',
+                  description: 'Automated review request for lessons with outdated metadata',
+                });
+              } else {
+                throw error;
+              }
+            }
+
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: LABEL,
+              state: 'open',
+              per_page: 100,
+            });
+
+            const openTitles = new Set(existing.data.map((issue) => issue.title));
+            const files = fs.readdirSync(LESSONS_DIR).filter((f) => f.endsWith('.json')).sort();
+
+            let checked = 0;
+            let staleFound = 0;
+            let opened = 0;
+            let skippedDuplicate = 0;
+
+            for (const file of files) {
+              const lesson = JSON.parse(fs.readFileSync(path.join(LESSONS_DIR, file), 'utf8'));
+              checked += 1;
+
+              if (lesson.keepStatus === 'drop') continue;
+              if (lesson.creativeWorkStatus === 'Archived') continue;
+
+              const dateStr = (lesson.dateModified || lesson.dateCreated || '').trim();
+              if (!dateStr) continue;
+
+              const lastModified = parseDate(dateStr);
+              if (!lastModified) continue;
+
+              if (!isStale(lastModified)) continue;
+
+              staleFound += 1;
+              const issueTitle = `Review needed: ${lesson.name}`;
+              if (openTitles.has(issueTitle)) {
+                skippedDuplicate += 1;
+                continue;
+              }
+
+              const slug = getLessonSlug(file, lesson);
+              const monthsOld = monthsSince(lastModified);
+              const owner = lesson.campusOwner
+                ? ` Campus owner: **${lesson.campusOwner}**.`
+                : '';
+
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: issueTitle,
+                labels: [LABEL],
+                body: [
+                  '## Lesson review requested',
+                  '',
+                  `**Lesson:** [${lesson.name}](${LESSON_SITE_BASE}/${slug})`,
+                  `**Last modified:** ${dateStr} (${monthsOld} months ago)`,
+                  `**External URL:** ${lesson.url || '—'}${owner}`,
+                  '',
+                  '### Checklist',
+                  '',
+                  '- [ ] External URL still resolves and content is current',
+                  '- [ ] Learning objectives still accurate',
+                  '- [ ] Metadata fields up to date (level, time, keywords)',
+                  '- [ ] `dateModified` updated in the lesson JSON after review',
+                  '- [ ] If lesson is no longer relevant, set `creativeWorkStatus: Archived`',
+                  '',
+                  '_This issue was opened automatically by the staleness detection workflow._',
+                ].join('\n'),
+              });
+
+              openTitles.add(issueTitle);
+              opened += 1;
+            }
+
+            const summary = [
+              `Lessons checked: ${checked}`,
+              `Stale lessons found: ${staleFound}`,
+              `Issues opened: ${opened}`,
+              `Skipped (duplicate open issue): ${skippedDuplicate}`,
+            ].join('\n');
+
+            core.summary.addHeading('Lesson staleness check');
+            core.summary.addRaw(summary);
+            await core.summary.write();
+
+            console.log(summary);

--- a/public/styles.css
+++ b/public/styles.css
@@ -575,12 +575,12 @@ summary:focus-visible {
 
 .site-footer__legal-link {
   font-size: 0.8rem;
-  color: rgba(255, 255, 255, 0.7);
+  color: var(--text-secondary);
   text-decoration: none;
 }
 
 .site-footer__legal-link:hover {
-  color: #fff;
+  color: var(--text-primary);
   text-decoration: underline;
 }
 

--- a/scripts/fetch-github-health.mjs
+++ b/scripts/fetch-github-health.mjs
@@ -1,7 +1,7 @@
 /**
  * Fetches GitHub repository health signals and CITATION.cff data for all
- * lessons that have a repoUrl. Writes a snapshot to src/data/github-health.json
- * for use at build time.
+ * lessons. Writes a slug-keyed snapshot to src/data/github-health.json for use
+ * at build time.
  *
  * Usage:
  *   GITHUB_TOKEN=your_token node scripts/fetch-github-health.mjs
@@ -19,20 +19,128 @@ const outputPath = join(__dirname, '../src/data/github-health.json');
 
 function parseGithubRepo(url) {
   if (!url || url === 'null') return null;
+
   try {
     const u = new URL(url);
-    if (u.hostname !== 'github.com') return null;
     const parts = u.pathname.split('/').filter(Boolean);
-    if (parts.length < 2) return null;
-    return { owner: parts[0], repo: parts[1] };
+
+    if (u.hostname === 'github.com') {
+      if (parts.length < 2) return null;
+      return {
+        owner: parts[0],
+        repo: parts[1].replace(/\.git$/, ''),
+      };
+    }
+
+    const pagesMatch = u.hostname.match(/^([a-z0-9-]+)\.github\.io$/i);
+    if (pagesMatch && parts.length >= 1) {
+      return {
+        owner: pagesMatch[1],
+        repo: parts[0],
+      };
+    }
   } catch {
     return null;
   }
+
+  return null;
+}
+
+function getLessonSlug(file, lesson) {
+  const fromLesson = typeof lesson.slug === 'string' ? lesson.slug.trim() : '';
+  return fromLesson || file.replace(/\.json$/, '');
+}
+
+function getLessonRepo(lesson) {
+  return parseGithubRepo(lesson.repoUrl?.trim()) ?? parseGithubRepo(lesson.url?.trim());
+}
+
+function repoKey({ owner, repo }) {
+  return `${owner.toLowerCase()}/${repo.toLowerCase()}`;
+}
+
+function repoUrl({ owner, repo }) {
+  return `https://github.com/${owner}/${repo}`;
 }
 
 function formatDate(isoString) {
   if (!isoString) return null;
   return isoString.slice(0, 10);
+}
+
+async function fetchJson(url, headers) {
+  const res = await fetch(url, { headers });
+  if (!res.ok) return { ok: false, status: res.status, data: null };
+  return { ok: true, status: res.status, data: await res.json() };
+}
+
+async function fetchContentPath(owner, repo, path, headers) {
+  const encodedPath = path.split('/').map(encodeURIComponent).join('/');
+  const url = `https://api.github.com/repos/${owner}/${repo}/contents/${encodedPath}`;
+  const res = await fetch(url, { headers });
+  if (!res.ok) return null;
+  return await res.json();
+}
+
+function decodeContent(content) {
+  if (!content?.content || content.encoding !== 'base64') return '';
+  return Buffer.from(content.content, 'base64').toString('utf8');
+}
+
+function normaliseFundingGithubValue(value) {
+  if (Array.isArray(value)) return value.find(Boolean) ?? null;
+  if (typeof value === 'string' && value.trim()) return value.trim();
+  return null;
+}
+
+async function fetchFunding(owner, repo, headers) {
+  const paths = ['.github/FUNDING.yml', 'FUNDING.yml'];
+
+  for (const path of paths) {
+    const file = await fetchContentPath(owner, repo, path, headers);
+    if (!file) continue;
+
+    let sponsorsUrl = `https://github.com/sponsors/${owner}`;
+    try {
+      const funding = yaml.load(decodeContent(file));
+      if (funding && typeof funding === 'object') {
+        const githubSponsor = normaliseFundingGithubValue(funding.github);
+        if (githubSponsor) {
+          sponsorsUrl = `https://github.com/sponsors/${githubSponsor}`;
+        }
+      }
+    } catch {
+      // Presence is enough to display the sustainable funding signal.
+    }
+
+    return { hasFunding: true, sponsorsUrl };
+  }
+
+  return { hasFunding: false, sponsorsUrl: null };
+}
+
+async function fetchCodeOfConduct(owner, repo, headers) {
+  const profile = await fetchJson(
+    `https://api.github.com/repos/${owner}/${repo}/community/profile`,
+    headers,
+  );
+
+  if (profile.ok && profile.data?.files?.code_of_conduct) {
+    return true;
+  }
+
+  const paths = [
+    'CODE_OF_CONDUCT.md',
+    'CODE_OF_CONDUCT',
+    '.github/CODE_OF_CONDUCT.md',
+    'docs/CODE_OF_CONDUCT.md',
+  ];
+
+  for (const path of paths) {
+    if (await fetchContentPath(owner, repo, path, headers)) return true;
+  }
+
+  return false;
 }
 
 /**
@@ -66,9 +174,7 @@ function coerceDate(value) {
     return isNaN(value.getTime()) ? null : value.toISOString().slice(0, 10);
   }
   if (typeof value === 'string') {
-    // Already ISO — return as-is
     if (/^\d{4}-\d{2}-\d{2}$/.test(value)) return value;
-    // Try parsing other formats
     const d = new Date(value);
     return isNaN(d.getTime()) ? null : d.toISOString().slice(0, 10);
   }
@@ -83,7 +189,7 @@ function isCffTemplate(cff) {
   if (cff.title === 'FIXME') return true;
   if (Array.isArray(cff.authors)) {
     const allFixme = cff.authors.every(
-      (a) => a['family-names'] === 'FIXME' || a['given-names'] === 'FIXME' || a.name === 'FIXME'
+      (a) => a['family-names'] === 'FIXME' || a['given-names'] === 'FIXME' || a.name === 'FIXME',
     );
     if (allFixme) return true;
   }
@@ -100,11 +206,10 @@ async function fetchCitation(owner, repo, defaultBranch, headers) {
 
   let res = await fetch(url, { headers });
 
-  // Some repos use 'master' when defaultBranch wasn't returned
   if (!res.ok && branch !== 'master') {
     res = await fetch(
       `https://raw.githubusercontent.com/${owner}/${repo}/master/CITATION.cff`,
-      { headers }
+      { headers },
     );
   }
 
@@ -122,7 +227,7 @@ async function fetchCitation(owner, repo, defaultBranch, headers) {
   if (!cff || typeof cff !== 'object') return null;
 
   if (isCffTemplate(cff)) {
-    console.warn(`    CITATION.cff is an unfilled template — skipping`);
+    console.warn('    CITATION.cff is an unfilled template — skipping');
     return null;
   }
 
@@ -130,18 +235,16 @@ async function fetchCitation(owner, repo, defaultBranch, headers) {
     ? cff.authors.map(normaliseCffAuthor).filter(Boolean)
     : [];
 
-  // DOI can be top-level (cff.doi) or buried in identifiers[].value as a doi.org URL
   let doi = cff.doi ?? null;
   if (!doi && Array.isArray(cff.identifiers)) {
     const doiEntry = cff.identifiers.find(
-      (id) => id.type === 'doi' || (id.type === 'url' && String(id.value ?? '').includes('doi.org'))
+      (id) => id.type === 'doi' || (id.type === 'url' && String(id.value ?? '').includes('doi.org')),
     );
     if (doiEntry) {
       doi = String(doiEntry.value).replace('https://doi.org/', '').replace('http://doi.org/', '');
     }
   }
 
-  // version can sometimes be a non-sensible date string — keep only sane values
   const rawVersion = cff.version != null ? String(cff.version) : null;
   const version = rawVersion && rawVersion.length < 40 && !/GMT|UTC/.test(rawVersion)
     ? rawVersion
@@ -174,7 +277,7 @@ async function fetchRepoHealth(owner, repo, headers) {
 
   const contribRes = await fetch(
     `https://api.github.com/repos/${owner}/${repo}/contributors?per_page=100&anon=false`,
-    { headers }
+    { headers },
   );
   let contributorCount = null;
   let contributorCountTruncated = false;
@@ -186,14 +289,22 @@ async function fetchRepoHealth(owner, repo, headers) {
     }
   }
 
-  const citation = await fetchCitation(owner, repo, data.default_branch, headers);
+  const [citation, funding, hasCodeOfConduct] = await Promise.all([
+    fetchCitation(owner, repo, data.default_branch, headers),
+    fetchFunding(owner, repo, headers),
+    fetchCodeOfConduct(owner, repo, headers),
+  ]);
+
   if (citation) {
-    console.log(`    CITATION.cff found — ${citation.authors.length} author(s)${citation.doi ? ', DOI: ' + citation.doi : ''}`);
+    console.log(
+      `    CITATION.cff found — ${citation.authors.length} author(s)${citation.doi ? ', DOI: ' + citation.doi : ''}`,
+    );
   } else {
-    console.log(`    No CITATION.cff`);
+    console.log('    No CITATION.cff');
   }
 
   return {
+    repoUrl: data.html_url ?? repoUrl({ owner, repo }),
     stars: data.stargazers_count ?? 0,
     forks: data.forks_count ?? 0,
     openIssues: data.open_issues_count ?? 0,
@@ -203,6 +314,9 @@ async function fetchRepoHealth(owner, repo, headers) {
     contributorCountTruncated,
     license: data.license?.spdx_id ?? null,
     archived: data.archived ?? false,
+    sponsorsUrl: funding.sponsorsUrl,
+    hasFunding: funding.hasFunding,
+    hasCodeOfConduct,
     citation,
   };
 }
@@ -218,47 +332,45 @@ async function main() {
     ...(token ? { Authorization: `Bearer ${token}` } : {}),
   };
 
-  const files = readdirSync(lessonsDir).filter((f) => f.endsWith('.json'));
-
-  // Collect unique repoUrls and which lessons map to them
-  const repoMap = new Map();
-  for (const file of files) {
+  const files = readdirSync(lessonsDir).filter((f) => f.endsWith('.json')).sort();
+  const lessons = files.map((file) => {
     const lesson = JSON.parse(readFileSync(join(lessonsDir, file), 'utf8'));
-    const repoUrl = lesson.repoUrl?.trim();
-    if (!repoUrl) continue;
-    const parsed = parseGithubRepo(repoUrl);
-    if (!parsed) {
-      console.log(`  Skip: ${lesson.name} (no valid GitHub repo URL: ${repoUrl})`);
-      continue;
-    }
-    if (!repoMap.has(repoUrl)) {
-      repoMap.set(repoUrl, { parsed, names: [] });
-    }
-    repoMap.get(repoUrl).names.push(lesson.name);
+    return { file, lesson, slug: getLessonSlug(file, lesson), parsed: getLessonRepo(lesson) };
+  });
+
+  const uniqueRepos = new Map();
+  for (const item of lessons) {
+    if (!item.parsed) continue;
+    const key = repoKey(item.parsed);
+    if (!uniqueRepos.has(key)) uniqueRepos.set(key, item.parsed);
   }
 
-  console.log(`\nFetching health + citations for ${repoMap.size} unique repos (${files.length} lessons)...\n`);
+  console.log(`\nFetching health + citations for ${uniqueRepos.size} unique repos (${files.length} lessons)...\n`);
 
-  const results = {};
+  const healthByRepo = new Map();
   let fetched = 0;
   let skipped = 0;
 
-  for (const [repoUrl, { parsed, names }] of repoMap) {
-    const label = `${parsed.owner}/${parsed.repo}`;
-    console.log(`  Fetch: ${label}  (${names.join(', ')})`);
-
+  for (const [key, parsed] of uniqueRepos) {
+    console.log(`  Fetch: ${parsed.owner}/${parsed.repo}`);
     const health = await fetchRepoHealth(parsed.owner, parsed.repo, headers);
+    healthByRepo.set(key, health);
+
     if (health) {
-      results[repoUrl] = health;
       fetched++;
       console.log(
-        `    stars=${health.stars} pushed=${health.pushedAt} contributors=${health.contributorCount}${health.contributorCountTruncated ? '+' : ''}`
+        `    stars=${health.stars} pushed=${health.pushedAt} contributors=${health.contributorCount}${health.contributorCountTruncated ? '+' : ''}`,
       );
     } else {
       skipped++;
     }
 
     await new Promise((r) => setTimeout(r, 250));
+  }
+
+  const results = {};
+  for (const item of lessons) {
+    results[item.slug] = item.parsed ? healthByRepo.get(repoKey(item.parsed)) ?? null : null;
   }
 
   const output = {

--- a/src/components/HealthSignalRow.jsx
+++ b/src/components/HealthSignalRow.jsx
@@ -1,0 +1,130 @@
+const compactNumberFormatter = new Intl.NumberFormat("en", {
+  notation: "compact",
+  maximumFractionDigits: 1,
+});
+
+function formatCompactNumber(value) {
+  return compactNumberFormatter.format(value ?? 0);
+}
+
+function formatRelativeDate(dateString) {
+  if (!dateString) return "";
+  const date = new Date(`${dateString}T00:00:00Z`);
+  if (Number.isNaN(date.getTime())) return "";
+
+  const now = new Date();
+  const diffMs = Math.max(0, now.getTime() - date.getTime());
+  const diffDays = Math.floor(diffMs / 86400000);
+
+  if (diffDays < 30) return `${Math.max(1, diffDays)}d ago`;
+
+  const diffMonths =
+    (now.getUTCFullYear() - date.getUTCFullYear()) * 12 +
+    (now.getUTCMonth() - date.getUTCMonth());
+
+  if (diffMonths < 12) return `${Math.max(1, diffMonths)}mo ago`;
+  return `${Math.floor(diffMonths / 12)}y ago`;
+}
+
+function isStale(dateString) {
+  if (!dateString) return false;
+  const date = new Date(`${dateString}T00:00:00Z`);
+  if (Number.isNaN(date.getTime())) return false;
+
+  const now = new Date();
+  const monthDiff =
+    (now.getUTCFullYear() - date.getUTCFullYear()) * 12 +
+    (now.getUTCMonth() - date.getUTCMonth());
+
+  return monthDiff > 18 || (monthDiff === 18 && now.getUTCDate() > date.getUTCDate());
+}
+
+function stopCardNavigation(event) {
+  event.stopPropagation();
+}
+
+/**
+ * @param {{ health: import("../lib/githubHealth").HealthRecord | null | undefined }} props
+ */
+export default function HealthSignalRow({ health }) {
+  if (!health) return null;
+
+  const repoUrl = health.repoUrl;
+  const stars = health.stars ?? 0;
+  const relativePushedAt = formatRelativeDate(health.pushedAt);
+  const stale = isStale(health.pushedAt);
+  const contributorLabel = health.contributorCount == null
+    ? null
+    : `${formatCompactNumber(health.contributorCount)}${health.contributorCountTruncated ? "+" : ""}`;
+
+  return (
+    <div className="lesson-card__health" role="group" aria-label="GitHub repository health signals">
+      {repoUrl ? (
+        <a
+          href={repoUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          title="Star this lesson on GitHub"
+          aria-label={`${stars} stars — Star this lesson on GitHub (opens in new tab)`}
+          className="lesson-card__health-link"
+          onClick={stopCardNavigation}
+        >
+          <span aria-hidden="true">⭐</span> {formatCompactNumber(stars)}
+        </a>
+      ) : (
+        <span className="lesson-card__health-item" title={`${stars} stars`}>
+          <span aria-hidden="true">⭐</span> {formatCompactNumber(stars)}
+        </span>
+      )}
+
+      <span className="lesson-card__health-item" title={`${health.forks ?? 0} forks`}>
+        <span aria-hidden="true">🍴</span> {formatCompactNumber(health.forks ?? 0)}
+      </span>
+
+      {contributorLabel && (
+        <span
+          className="lesson-card__health-item"
+          title={`${health.contributorCount}${health.contributorCountTruncated ? "+" : ""} contributors`}
+        >
+          <span aria-hidden="true">👥</span> {contributorLabel}
+        </span>
+      )}
+
+      {relativePushedAt && (
+        <span className={`lesson-card__health-item${stale ? " lesson-card__health-item--stale" : ""}`}>
+          Updated {relativePushedAt}
+        </span>
+      )}
+
+      {health.license && (
+        <span className="lesson-card__health-item" title={`License: ${health.license}`}>
+          {health.license}
+        </span>
+      )}
+
+      {health.hasFunding && health.sponsorsUrl && (
+        <a
+          href={health.sponsorsUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="lesson-card__health-link lesson-card__health-link--sponsor"
+          aria-label="Sponsor this lesson's maintainers on GitHub (opens in new tab)"
+          onClick={stopCardNavigation}
+        >
+          <span aria-hidden="true">💚</span> Sponsorable
+        </a>
+      )}
+
+      {health.hasCodeOfConduct && (
+        <span
+          className="lesson-card__health-item"
+          title="Has Code of Conduct"
+          role="img"
+          aria-label="Has Code of Conduct"
+        >
+          <span aria-hidden="true">🤝</span>
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/components/LessonCard.jsx
+++ b/src/components/LessonCard.jsx
@@ -1,5 +1,10 @@
 import { ChartBarIcon } from "@heroicons/react/24/outline";
 
+const compactNumberFormatter = new Intl.NumberFormat("en", {
+  notation: "compact",
+  maximumFractionDigits: 1,
+});
+
 function formatUrlLabel(url) {
   try {
     const parsed = new URL(url);
@@ -18,7 +23,129 @@ function getLevelConfig(level) {
   return { bg: "#6b7280", label: level };
 }
 
-export default function LessonCard({ lesson, lessonIndex = {}, headingLevel = 3 }) {
+function formatCompactNumber(value) {
+  return compactNumberFormatter.format(value ?? 0);
+}
+
+function formatRelativeDate(dateString) {
+  if (!dateString) return "";
+  const date = new Date(`${dateString}T00:00:00Z`);
+  if (Number.isNaN(date.getTime())) return "";
+
+  const now = new Date();
+  const diffMs = Math.max(0, now.getTime() - date.getTime());
+  const diffDays = Math.floor(diffMs / 86400000);
+
+  if (diffDays < 30) return `${Math.max(1, diffDays)}d ago`;
+
+  const diffMonths =
+    (now.getUTCFullYear() - date.getUTCFullYear()) * 12 +
+    (now.getUTCMonth() - date.getUTCMonth());
+
+  if (diffMonths < 12) return `${Math.max(1, diffMonths)}mo ago`;
+  return `${Math.floor(diffMonths / 12)}y ago`;
+}
+
+function isStale(dateString) {
+  if (!dateString) return false;
+  const date = new Date(`${dateString}T00:00:00Z`);
+  if (Number.isNaN(date.getTime())) return false;
+
+  const now = new Date();
+  const monthDiff =
+    (now.getUTCFullYear() - date.getUTCFullYear()) * 12 +
+    (now.getUTCMonth() - date.getUTCMonth());
+
+  return monthDiff > 18 || (monthDiff === 18 && now.getUTCDate() > date.getUTCDate());
+}
+
+function stopCardNavigation(event) {
+  event.stopPropagation();
+}
+
+function HealthSignalRow({ health }) {
+  if (!health) return null;
+
+  const repoUrl = health.repoUrl;
+  const stars = health.stars ?? 0;
+  const relativePushedAt = formatRelativeDate(health.pushedAt);
+  const stale = isStale(health.pushedAt);
+  const contributorLabel = health.contributorCount == null
+    ? null
+    : `${formatCompactNumber(health.contributorCount)}${health.contributorCountTruncated ? "+" : ""}`;
+
+  return (
+    <div className="lesson-card__health" aria-label="GitHub repository health signals">
+      {repoUrl ? (
+        <a
+          href={repoUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          title="Star this lesson on GitHub"
+          aria-label={`${stars} stars — Star this lesson on GitHub (opens in new tab)`}
+          className="lesson-card__health-link"
+          onClick={stopCardNavigation}
+        >
+          <span aria-hidden="true">⭐</span> {formatCompactNumber(stars)}
+        </a>
+      ) : (
+        <span className="lesson-card__health-item" title={`${stars} stars`}>
+          <span aria-hidden="true">⭐</span> {formatCompactNumber(stars)}
+        </span>
+      )}
+
+      <span className="lesson-card__health-item" title={`${health.forks ?? 0} forks`}>
+        <span aria-hidden="true">🍴</span> {formatCompactNumber(health.forks ?? 0)}
+      </span>
+
+      {contributorLabel && (
+        <span
+          className="lesson-card__health-item"
+          title={`${health.contributorCount}${health.contributorCountTruncated ? "+" : ""} contributors`}
+        >
+          <span aria-hidden="true">👥</span> {contributorLabel}
+        </span>
+      )}
+
+      {relativePushedAt && (
+        <span className={`lesson-card__health-item${stale ? " lesson-card__health-item--stale" : ""}`}>
+          Updated {relativePushedAt}
+        </span>
+      )}
+
+      {health.license && (
+        <span className="lesson-card__health-item" title={`License: ${health.license}`}>
+          {health.license}
+        </span>
+      )}
+
+      {health.hasFunding && health.sponsorsUrl && (
+        <a
+          href={health.sponsorsUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="lesson-card__health-link lesson-card__health-link--sponsor"
+          aria-label="Sponsor this lesson's maintainers on GitHub (opens in new tab)"
+          onClick={stopCardNavigation}
+        >
+          <span aria-hidden="true">💚</span> Sponsorable
+        </a>
+      )}
+
+      {health.hasCodeOfConduct && (
+        <span
+          className="lesson-card__health-item"
+          title="Has Code of Conduct"
+          aria-label="Has Code of Conduct"
+        >
+          <span aria-hidden="true">🤝</span>
+        </span>
+      )}
+    </div>
+  );
+}
+
+export default function LessonCard({ lesson, lessonIndex = {}, headingLevel = 3, health = null }) {
   if (!lesson) return null;
 
   const lessonName = lesson.name || "Untitled Lesson";
@@ -56,7 +183,9 @@ export default function LessonCard({ lesson, lessonIndex = {}, headingLevel = 3 
   const TitleTag = `h${headingLevel}`;
 
   return (
-    <a className="lesson-card" href={lessonHref}>
+    <article className="lesson-card">
+      <a className="lesson-card__cover-link" href={lessonHref} aria-label="Open lesson page"></a>
+
       {/* Colored level band */}
       <div className="lesson-card__band" style={{ background: level.bg }}>
         <ChartBarIcon className="lesson-card__band-icon" />
@@ -112,7 +241,9 @@ export default function LessonCard({ lesson, lessonIndex = {}, headingLevel = 3 
             ✨ Featured in multiple pathways
           </p>
         )}
+
+        <HealthSignalRow health={health} />
       </div>
-    </a>
+    </article>
   );
 }

--- a/src/components/LessonCard.jsx
+++ b/src/components/LessonCard.jsx
@@ -1,5 +1,7 @@
 import { ChartBarIcon } from "@heroicons/react/24/outline";
 
+/** @typedef {import("../lib/githubHealth").HealthRecord} HealthRecord */
+
 const compactNumberFormatter = new Intl.NumberFormat("en", {
   notation: "compact",
   maximumFractionDigits: 1,
@@ -75,7 +77,7 @@ function HealthSignalRow({ health }) {
     : `${formatCompactNumber(health.contributorCount)}${health.contributorCountTruncated ? "+" : ""}`;
 
   return (
-    <div className="lesson-card__health" aria-label="GitHub repository health signals">
+    <div className="lesson-card__health" role="group" aria-label="GitHub repository health signals">
       {repoUrl ? (
         <a
           href={repoUrl}
@@ -136,6 +138,7 @@ function HealthSignalRow({ health }) {
         <span
           className="lesson-card__health-item"
           title="Has Code of Conduct"
+          role="img"
           aria-label="Has Code of Conduct"
         >
           <span aria-hidden="true">🤝</span>
@@ -145,6 +148,14 @@ function HealthSignalRow({ health }) {
   );
 }
 
+/**
+ * @param {{
+ *   lesson: import("../lib/lessons").Lesson;
+ *   lessonIndex?: Record<string, { name: string; url: string }>;
+ *   headingLevel?: number;
+ *   health?: HealthRecord | null;
+ * }} props
+ */
 export default function LessonCard({ lesson, lessonIndex = {}, headingLevel = 3, health = null }) {
   if (!lesson) return null;
 

--- a/src/components/LessonCard.jsx
+++ b/src/components/LessonCard.jsx
@@ -1,11 +1,7 @@
 import { ChartBarIcon } from "@heroicons/react/24/outline";
+import HealthSignalRow from "./HealthSignalRow.jsx";
 
 /** @typedef {import("../lib/githubHealth").HealthRecord} HealthRecord */
-
-const compactNumberFormatter = new Intl.NumberFormat("en", {
-  notation: "compact",
-  maximumFractionDigits: 1,
-});
 
 function formatUrlLabel(url) {
   try {
@@ -23,129 +19,6 @@ function getLevelConfig(level) {
   if (n.includes("intermediate")) return { bg: "#a85a00", label: "Intermediate" };
   if (n.includes("advanced"))     return { bg: "#8a2530", label: "Advanced" };
   return { bg: "#6b7280", label: level };
-}
-
-function formatCompactNumber(value) {
-  return compactNumberFormatter.format(value ?? 0);
-}
-
-function formatRelativeDate(dateString) {
-  if (!dateString) return "";
-  const date = new Date(`${dateString}T00:00:00Z`);
-  if (Number.isNaN(date.getTime())) return "";
-
-  const now = new Date();
-  const diffMs = Math.max(0, now.getTime() - date.getTime());
-  const diffDays = Math.floor(diffMs / 86400000);
-
-  if (diffDays < 30) return `${Math.max(1, diffDays)}d ago`;
-
-  const diffMonths =
-    (now.getUTCFullYear() - date.getUTCFullYear()) * 12 +
-    (now.getUTCMonth() - date.getUTCMonth());
-
-  if (diffMonths < 12) return `${Math.max(1, diffMonths)}mo ago`;
-  return `${Math.floor(diffMonths / 12)}y ago`;
-}
-
-function isStale(dateString) {
-  if (!dateString) return false;
-  const date = new Date(`${dateString}T00:00:00Z`);
-  if (Number.isNaN(date.getTime())) return false;
-
-  const now = new Date();
-  const monthDiff =
-    (now.getUTCFullYear() - date.getUTCFullYear()) * 12 +
-    (now.getUTCMonth() - date.getUTCMonth());
-
-  return monthDiff > 18 || (monthDiff === 18 && now.getUTCDate() > date.getUTCDate());
-}
-
-function stopCardNavigation(event) {
-  event.stopPropagation();
-}
-
-function HealthSignalRow({ health }) {
-  if (!health) return null;
-
-  const repoUrl = health.repoUrl;
-  const stars = health.stars ?? 0;
-  const relativePushedAt = formatRelativeDate(health.pushedAt);
-  const stale = isStale(health.pushedAt);
-  const contributorLabel = health.contributorCount == null
-    ? null
-    : `${formatCompactNumber(health.contributorCount)}${health.contributorCountTruncated ? "+" : ""}`;
-
-  return (
-    <div className="lesson-card__health" role="group" aria-label="GitHub repository health signals">
-      {repoUrl ? (
-        <a
-          href={repoUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          title="Star this lesson on GitHub"
-          aria-label={`${stars} stars — Star this lesson on GitHub (opens in new tab)`}
-          className="lesson-card__health-link"
-          onClick={stopCardNavigation}
-        >
-          <span aria-hidden="true">⭐</span> {formatCompactNumber(stars)}
-        </a>
-      ) : (
-        <span className="lesson-card__health-item" title={`${stars} stars`}>
-          <span aria-hidden="true">⭐</span> {formatCompactNumber(stars)}
-        </span>
-      )}
-
-      <span className="lesson-card__health-item" title={`${health.forks ?? 0} forks`}>
-        <span aria-hidden="true">🍴</span> {formatCompactNumber(health.forks ?? 0)}
-      </span>
-
-      {contributorLabel && (
-        <span
-          className="lesson-card__health-item"
-          title={`${health.contributorCount}${health.contributorCountTruncated ? "+" : ""} contributors`}
-        >
-          <span aria-hidden="true">👥</span> {contributorLabel}
-        </span>
-      )}
-
-      {relativePushedAt && (
-        <span className={`lesson-card__health-item${stale ? " lesson-card__health-item--stale" : ""}`}>
-          Updated {relativePushedAt}
-        </span>
-      )}
-
-      {health.license && (
-        <span className="lesson-card__health-item" title={`License: ${health.license}`}>
-          {health.license}
-        </span>
-      )}
-
-      {health.hasFunding && health.sponsorsUrl && (
-        <a
-          href={health.sponsorsUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="lesson-card__health-link lesson-card__health-link--sponsor"
-          aria-label="Sponsor this lesson's maintainers on GitHub (opens in new tab)"
-          onClick={stopCardNavigation}
-        >
-          <span aria-hidden="true">💚</span> Sponsorable
-        </a>
-      )}
-
-      {health.hasCodeOfConduct && (
-        <span
-          className="lesson-card__health-item"
-          title="Has Code of Conduct"
-          role="img"
-          aria-label="Has Code of Conduct"
-        >
-          <span aria-hidden="true">🤝</span>
-        </span>
-      )}
-    </div>
-  );
 }
 
 /**

--- a/src/components/LessonFilter.tsx
+++ b/src/components/LessonFilter.tsx
@@ -2,12 +2,14 @@ import { useEffect, useMemo, useState } from "react";
 import Fuse from "fuse.js";
 import LessonCard from "./LessonCard.jsx";
 import type { Lesson } from "../lib/lessons";
+import type { HealthRecord } from "../lib/githubHealth";
 
 interface LessonFilterProps {
   lessons: Lesson[];
+  healthBySlug?: Record<string, HealthRecord | null>;
 }
 
-export default function LessonFilter({ lessons }: LessonFilterProps) {
+export default function LessonFilter({ lessons, healthBySlug = {} }: LessonFilterProps) {
   const [isLoading, setIsLoading] = useState(true);
   const [filters, setFilters] = useState({
     role: "",
@@ -60,7 +62,7 @@ export default function LessonFilter({ lessons }: LessonFilterProps) {
         { name: "keywords", weight: 0.2 },
         { name: "subTopic", weight: 0.1 },
       ],
-      threshold: 0.4,
+      threshold: 0.3,
       ignoreLocation: true,
     });
   }, [lessons]);
@@ -198,6 +200,7 @@ export default function LessonFilter({ lessons }: LessonFilterProps) {
               key={lesson.slug}
               lesson={lesson}
               lessonIndex={lessonIndex}
+              health={healthBySlug[lesson.slug] ?? null}
             />
           ))
         )}

--- a/src/components/home/LessonPreviewCard.tsx
+++ b/src/components/home/LessonPreviewCard.tsx
@@ -1,11 +1,14 @@
 import { ChartBarIcon } from '@heroicons/react/24/outline';
+import HealthSignalRow from '../HealthSignalRow.jsx';
 import type { Lesson } from '../../lib/lessons';
+import type { HealthRecord } from '../../lib/githubHealth';
 import type { ReactNode } from 'react';
 
 type LessonPreviewCardProps = {
   lesson: Lesson;
   pathwayIcon?: ReactNode;
   compact?: boolean;
+  health?: HealthRecord | null;
 };
 
 function getLevelConfig(level: string | undefined) {
@@ -21,6 +24,7 @@ export default function LessonPreviewCard({
   lesson,
   pathwayIcon,
   compact = false,
+  health = null,
 }: LessonPreviewCardProps) {
   const href = `${import.meta.env.BASE_URL}lessons/${lesson.slug}`;
   const roles = (lesson.roles ?? []).slice(0, 2);
@@ -29,7 +33,9 @@ export default function LessonPreviewCard({
   const level = getLevelConfig(lesson.educationalLevel);
 
   return (
-    <a className={`home-lesson-card ${compactClass}`.trim()} href={href}>
+    <article className={`home-lesson-card ${compactClass}`.trim()}>
+      <a className="home-lesson-card__cover-link" href={href} aria-label={`Open ${lesson.name}`} />
+
       {/* ── Colored level band ── */}
       <div
         className="home-lesson-card__level-band"
@@ -58,7 +64,9 @@ export default function LessonPreviewCard({
         <p className="home-lesson-card__description">
           {lesson.description || lesson.abstract || 'No description available yet.'}
         </p>
+
+        <HealthSignalRow health={health} />
       </div>
-    </a>
+    </article>
   );
 }

--- a/src/components/home/LessonRail.tsx
+++ b/src/components/home/LessonRail.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import type { Lesson } from '../../lib/lessons';
+import type { HealthRecord } from '../../lib/githubHealth';
 import type { ReactNode } from 'react';
 import LessonPreviewCard from './LessonPreviewCard';
 
@@ -9,6 +10,7 @@ type LessonRailProps = {
   pathwayIcon?: ReactNode;
   showProgress?: boolean;
   initialVisibleCount?: number;
+  healthBySlug?: Record<string, HealthRecord | null>;
 };
 
 export default function LessonRail({
@@ -17,6 +19,7 @@ export default function LessonRail({
   pathwayIcon,
   showProgress = false,
   initialVisibleCount = 3,
+  healthBySlug = {},
 }: LessonRailProps) {
   const trackRef = useRef<HTMLDivElement | null>(null);
   const thumbRef = useRef<HTMLSpanElement | null>(null);
@@ -100,7 +103,12 @@ export default function LessonRail({
         <div className="home-lesson-rail__track" ref={trackRef}>
           {lessons.map((lesson) => (
             <div className="home-lesson-rail__item" key={lesson.slug}>
-              <LessonPreviewCard lesson={lesson} pathwayIcon={pathwayIcon} compact />
+              <LessonPreviewCard
+                lesson={lesson}
+                pathwayIcon={pathwayIcon}
+                compact
+                health={healthBySlug[lesson.slug] ?? null}
+              />
             </div>
           ))}
         </div>

--- a/src/components/home/PathwayShowcase.tsx
+++ b/src/components/home/PathwayShowcase.tsx
@@ -2,16 +2,19 @@ import { useState } from 'react';
 import CategoryIcon from './CategoryIcon';
 import CategoryPanel from './CategoryPanel';
 import LessonRail from './LessonRail';
+import type { HealthRecord } from '../../lib/githubHealth';
 import type { HomepagePathwayItem } from './types';
 
 type PathwayShowcaseProps = {
   items: HomepagePathwayItem[];
   defaultActiveId?: string;
+  healthBySlug?: Record<string, HealthRecord | null>;
 };
 
 export default function PathwayShowcase({
   items,
   defaultActiveId,
+  healthBySlug = {},
 }: PathwayShowcaseProps) {
   const initialId =
     items.find((item) => item.id === defaultActiveId)?.id ?? items[0]?.id ?? '';
@@ -41,6 +44,7 @@ export default function PathwayShowcase({
                     pathwayIcon={<CategoryIcon name={item.iconName} size={18} decorative />}
                     showProgress={section.lessons.length > 3}
                     initialVisibleCount={3}
+                    healthBySlug={healthBySlug}
                   />
                 ))
               ) : (

--- a/src/components/home/home.css
+++ b/src/components/home/home.css
@@ -129,7 +129,7 @@
 
 .home-category-tab__trigger:focus-visible,
 .home-browse-panel__button:focus-visible,
-.home-lesson-card:focus-visible {
+.home-lesson-card:focus-within {
   outline: 3px solid var(--uc-gold);
   outline-offset: 3px;
 }
@@ -265,6 +265,7 @@
 }
 
 .home-lesson-card {
+  position: relative;
   display: flex;
   min-height: 18rem;
   flex-direction: column;
@@ -278,6 +279,13 @@
   transition: box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
+.home-lesson-card__cover-link {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  border-radius: inherit;
+}
+
 .home-lesson-card:hover {
   color: inherit;
   text-decoration: none;
@@ -289,8 +297,15 @@
   min-height: 17rem;
 }
 
+.home-lesson-card .lesson-card__health {
+  margin-top: auto;
+}
+
 /* ── Full-width colored level band at the top ── */
 .home-lesson-card__level-band {
+  position: relative;
+  z-index: 2;
+  pointer-events: none;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -310,6 +325,9 @@
 
 /* ── Dark metadata strip below the band ── */
 .home-lesson-card__top {
+  position: relative;
+  z-index: 2;
+  pointer-events: none;
   padding: 0.6rem 1rem 0.7rem;
   background: var(--bg-subtle);
   border-bottom: 1px solid var(--border-light);
@@ -332,6 +350,9 @@
 
 /* ── Body: title + description ── */
 .home-lesson-card__body {
+  position: relative;
+  z-index: 2;
+  pointer-events: none;
   display: flex;
   flex: 1;
   flex-direction: column;

--- a/src/components/lessons/lessons.css
+++ b/src/components/lessons/lessons.css
@@ -143,6 +143,13 @@
   transition: box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
+.lesson-card__cover-link {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  border-radius: inherit;
+}
+
 .lesson-card:hover {
   color: inherit;
   text-decoration: none;
@@ -150,13 +157,16 @@
   box-shadow: var(--shadow-strong);
 }
 
-.lesson-card:focus-visible {
+.lesson-card:focus-within {
   outline: 3px solid var(--uc-gold);
   outline-offset: 3px;
 }
 
 /* Level band */
 .lesson-card__band {
+  position: relative;
+  z-index: 2;
+  pointer-events: none;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -178,6 +188,9 @@
 
 /* Metadata strip */
 .lesson-card__meta-strip {
+  position: relative;
+  z-index: 2;
+  pointer-events: none;
   padding: 0.6rem 1rem 0.7rem;
   background: var(--bg-subtle);
   border-bottom: 1px solid var(--border-light);
@@ -205,6 +218,9 @@
 
 /* Body */
 .lesson-card__body {
+  position: relative;
+  z-index: 2;
+  pointer-events: none;
   display: flex;
   flex: 1;
   flex-direction: column;
@@ -272,6 +288,9 @@
 }
 
 .lesson-card__prereq-link {
+  position: relative;
+  z-index: 3;
+  pointer-events: auto;
   display: inline-block;
   font-family: var(--font-sans);
   font-size: 0.75rem;
@@ -297,6 +316,9 @@
 
 /* Feedback link */
 .lesson-card__feedback {
+  position: relative;
+  z-index: 3;
+  pointer-events: auto;
   align-self: flex-end;
   margin-top: auto;
   font-family: var(--font-sans);
@@ -318,6 +340,52 @@
   text-decoration: none;
 }
 
+.lesson-card__health {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem 0.55rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--border-light);
+  color: var(--text-secondary);
+  font-family: var(--font-sans);
+  font-size: 0.74rem;
+  line-height: 1.35;
+}
+
+.lesson-card__health-item,
+.lesson-card__health-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.18rem;
+  min-height: 1.25rem;
+  color: inherit;
+  white-space: nowrap;
+}
+
+.lesson-card__health-link {
+  position: relative;
+  z-index: 3;
+  pointer-events: auto;
+  text-decoration: none;
+}
+
+.lesson-card__health-link:hover {
+  color: var(--uc-blue);
+  text-decoration: underline;
+  text-underline-offset: 0.16em;
+}
+
+.lesson-card__health-link:focus-visible {
+  outline: 2px solid var(--uc-gold);
+  outline-offset: 2px;
+}
+
+.lesson-card__health-item--stale {
+  color: #9a5a00;
+  font-weight: 600;
+}
+
 @media (prefers-color-scheme: dark) {
   .lesson-card__prereq-link {
     color: var(--uc-light-blue);
@@ -329,6 +397,14 @@
     color: var(--uc-light-blue);
     background: rgba(122, 179, 255, 0.14);
     border-color: rgba(122, 179, 255, 0.38);
+  }
+
+  .lesson-card__health-link:hover {
+    color: var(--uc-light-blue);
+  }
+
+  .lesson-card__health-item--stale {
+    color: #f0b35a;
   }
 
 }

--- a/src/data/github-health.json
+++ b/src/data/github-health.json
@@ -1,28 +1,36 @@
 {
-  "fetchedAt": "2026-05-24T22:47:10.444Z",
+  "fetchedAt": "2026-05-26T22:11:33.098Z",
   "lessons": {
-    "https://github.com/github/opensource.guide": {
-      "stars": 15456,
-      "forks": 15388,
-      "openIssues": 8,
+    "best-practices-for-maintainers": {
+      "repoUrl": "https://github.com/github/opensource.guide",
+      "stars": 15465,
+      "forks": 15393,
+      "openIssues": 9,
       "pushedAt": "2026-05-21",
-      "updatedAt": "2026-05-24",
+      "updatedAt": "2026-05-26",
       "contributorCount": 100,
       "contributorCountTruncated": true,
       "license": "CC-BY-4.0",
       "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": true,
       "citation": null
     },
-    "https://github.com/carpentries-incubator/better-research-software": {
+    "building-better-research-software": {
+      "repoUrl": "https://github.com/carpentries-incubator/better-research-software",
       "stars": 19,
       "forks": 20,
-      "openIssues": 34,
-      "pushedAt": "2026-05-19",
-      "updatedAt": "2026-05-05",
-      "contributorCount": 19,
+      "openIssues": 30,
+      "pushedAt": "2026-05-26",
+      "updatedAt": "2026-05-26",
+      "contributorCount": 20,
       "contributorCountTruncated": false,
       "license": "NOASSERTION",
       "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": true,
       "citation": {
         "source": "cff",
         "title": "Building Better Research Software",
@@ -82,7 +90,24 @@
         ]
       }
     },
-    "https://github.com/hsf-training/hsf-training-cicd": {
+    "building-community": {
+      "repoUrl": "https://github.com/github/opensource.guide",
+      "stars": 15465,
+      "forks": 15393,
+      "openIssues": 9,
+      "pushedAt": "2026-05-21",
+      "updatedAt": "2026-05-26",
+      "contributorCount": 100,
+      "contributorCountTruncated": true,
+      "license": "CC-BY-4.0",
+      "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": true,
+      "citation": null
+    },
+    "cicd-for-research-software-with-gitlab-ci": {
+      "repoUrl": "https://github.com/hsf-training/hsf-training-cicd",
       "stars": 5,
       "forks": 7,
       "openIssues": 7,
@@ -92,18 +117,25 @@
       "contributorCountTruncated": true,
       "license": "NOASSERTION",
       "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": true,
       "citation": null
     },
-    "https://github.com/the-turing-way/the-turing-way": {
-      "stars": 2147,
+    "collaboration-in-open-research-projects": {
+      "repoUrl": "https://github.com/the-turing-way/the-turing-way",
+      "stars": 2148,
       "forks": 749,
       "openIssues": 607,
-      "pushedAt": "2026-05-20",
-      "updatedAt": "2026-05-24",
+      "pushedAt": "2026-05-25",
+      "updatedAt": "2026-05-26",
       "contributorCount": 100,
       "contributorCountTruncated": true,
       "license": "NOASSERTION",
       "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": true,
       "citation": {
         "source": "cff",
         "title": "The Turing Way handbook for reproducible, ethical and collaborative research",
@@ -118,16 +150,20 @@
         ]
       }
     },
-    "https://github.com/coderefinery/git-collaborative": {
+    "collaborative-git-for-teams": {
+      "repoUrl": "https://github.com/coderefinery/git-collaborative",
       "stars": 10,
       "forks": 44,
-      "openIssues": 13,
+      "openIssues": 14,
       "pushedAt": "2026-03-30",
       "updatedAt": "2026-05-18",
       "contributorCount": 17,
       "contributorCountTruncated": false,
       "license": "CC-BY-4.0",
       "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": false,
       "citation": {
         "source": "cff",
         "title": "Collaborative distributed version control",
@@ -208,40 +244,132 @@
         ]
       }
     },
-    "https://github.com/INTERSECT-training/CI-CD": {
+    "continuous-integration-and-delivery-with-github-actions": {
+      "repoUrl": "https://github.com/INTERSECT-training/CI-CD",
       "stars": 0,
       "forks": 1,
       "openIssues": 1,
-      "pushedAt": "2026-05-19",
+      "pushedAt": "2026-05-26",
       "updatedAt": "2025-09-18",
       "contributorCount": 3,
       "contributorCountTruncated": false,
       "license": "NOASSERTION",
       "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": true,
       "citation": null
     },
-    "https://github.com/INTERSECT-training/Code-Review": {
+    "coordinate-reference-systems": {
+      "repoUrl": "https://github.com/ucdavisdatalab/workshop_coordinate_reference_systems",
+      "stars": 0,
+      "forks": 0,
+      "openIssues": 1,
+      "pushedAt": "2023-09-21",
+      "updatedAt": "2023-09-21",
+      "contributorCount": 1,
+      "contributorCountTruncated": false,
+      "license": null,
+      "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": false,
+      "citation": null
+    },
+    "developing-your-data-science-portfolio": {
+      "repoUrl": "https://github.com/ucdavisdatalab/workshop_portfolios",
+      "stars": 0,
+      "forks": 1,
+      "openIssues": 2,
+      "pushedAt": "2024-02-13",
+      "updatedAt": "2022-10-19",
+      "contributorCount": 2,
+      "contributorCountTruncated": false,
+      "license": "NOASSERTION",
+      "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": false,
+      "citation": null
+    },
+    "effective-code-review": {
+      "repoUrl": "https://github.com/INTERSECT-training/Code-Review",
       "stars": 0,
       "forks": 7,
       "openIssues": 1,
-      "pushedAt": "2026-05-19",
+      "pushedAt": "2026-05-26",
       "updatedAt": "2025-09-17",
       "contributorCount": 5,
       "contributorCountTruncated": false,
       "license": "NOASSERTION",
       "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": true,
       "citation": null
     },
-    "https://github.com/carpentries-incubator/python-intermediate-development": {
+    "finding-users-for-your-project": {
+      "repoUrl": "https://github.com/github/opensource.guide",
+      "stars": 15465,
+      "forks": 15393,
+      "openIssues": 9,
+      "pushedAt": "2026-05-21",
+      "updatedAt": "2026-05-26",
+      "contributorCount": 100,
+      "contributorCountTruncated": true,
+      "license": "CC-BY-4.0",
+      "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": true,
+      "citation": null
+    },
+    "geocoding": {
+      "repoUrl": "https://github.com/ucdavisdatalab/geocoding-workshop",
+      "stars": 5,
+      "forks": 2,
+      "openIssues": 1,
+      "pushedAt": "2021-02-16",
+      "updatedAt": "2024-02-27",
+      "contributorCount": 1,
+      "contributorCountTruncated": false,
+      "license": "GPL-3.0",
+      "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": false,
+      "citation": null
+    },
+    "how-to-contribute-to-open-source": {
+      "repoUrl": "https://github.com/github/opensource.guide",
+      "stars": 15465,
+      "forks": 15393,
+      "openIssues": 9,
+      "pushedAt": "2026-05-21",
+      "updatedAt": "2026-05-26",
+      "contributorCount": 100,
+      "contributorCountTruncated": true,
+      "license": "CC-BY-4.0",
+      "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": true,
+      "citation": null
+    },
+    "intermediate-python-development": {
+      "repoUrl": "https://github.com/carpentries-incubator/python-intermediate-development",
       "stars": 61,
       "forks": 77,
-      "openIssues": 70,
-      "pushedAt": "2026-05-23",
-      "updatedAt": "2026-05-23",
-      "contributorCount": 40,
+      "openIssues": 68,
+      "pushedAt": "2026-05-26",
+      "updatedAt": "2026-05-26",
+      "contributorCount": 41,
       "contributorCountTruncated": false,
       "license": "NOASSERTION",
       "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": true,
       "citation": {
         "source": "cff",
         "title": "Intermediate Research Software Development Skills (Python)",
@@ -511,7 +639,387 @@
         ]
       }
     },
-    "https://github.com/hsf-training/hsf-training-docker": {
+    "intermediate-python-next-level-data-visualization": {
+      "repoUrl": "https://github.com/ucdavisdatalab/workshop_intermediate_python",
+      "stars": 2,
+      "forks": 2,
+      "openIssues": 2,
+      "pushedAt": "2025-03-18",
+      "updatedAt": "2025-03-05",
+      "contributorCount": 1,
+      "contributorCountTruncated": false,
+      "license": "NOASSERTION",
+      "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": false,
+      "citation": null
+    },
+    "intermediate-python": {
+      "repoUrl": "https://github.com/ucdavisdatalab/workshop_intermediate_python",
+      "stars": 2,
+      "forks": 2,
+      "openIssues": 2,
+      "pushedAt": "2025-03-18",
+      "updatedAt": "2025-03-05",
+      "contributorCount": 1,
+      "contributorCountTruncated": false,
+      "license": "NOASSERTION",
+      "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": false,
+      "citation": null
+    },
+    "intermediate-r-next-level-data-visualization": {
+      "repoUrl": "https://github.com/ucdavisdatalab/workshop_intermediate_r",
+      "stars": 3,
+      "forks": 5,
+      "openIssues": 3,
+      "pushedAt": "2026-04-30",
+      "updatedAt": "2026-04-30",
+      "contributorCount": 4,
+      "contributorCountTruncated": false,
+      "license": "NOASSERTION",
+      "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": false,
+      "citation": null
+    },
+    "intermediate-r": {
+      "repoUrl": "https://github.com/ucdavisdatalab/workshop_intermediate_r",
+      "stars": 3,
+      "forks": 5,
+      "openIssues": 3,
+      "pushedAt": "2026-04-30",
+      "updatedAt": "2026-04-30",
+      "contributorCount": 4,
+      "contributorCountTruncated": false,
+      "license": "NOASSERTION",
+      "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": false,
+      "citation": null
+    },
+    "intermediate-research-software-development-skills-python-lesson-material": {
+      "repoUrl": "https://github.com/carpentries-incubator/python-intermediate-development",
+      "stars": 61,
+      "forks": 77,
+      "openIssues": 68,
+      "pushedAt": "2026-05-26",
+      "updatedAt": "2026-05-26",
+      "contributorCount": 41,
+      "contributorCountTruncated": false,
+      "license": "NOASSERTION",
+      "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": true,
+      "citation": {
+        "source": "cff",
+        "title": "Intermediate Research Software Development Skills (Python)",
+        "doi": "10.5281/zenodo.6532056",
+        "version": "beta-May2026",
+        "dateReleased": "2026-05-23",
+        "license": "CC-BY-4.0",
+        "authors": [
+          {
+            "family": "Nenadic",
+            "given": "Aleksandra",
+            "orcid": "0000-0002-2269-3894",
+            "affiliation": null
+          },
+          {
+            "family": "Crouch",
+            "given": "Steve",
+            "orcid": "0000-0001-8985-6814",
+            "affiliation": null
+          },
+          {
+            "family": "Kiley",
+            "given": "Thomas",
+            "orcid": null,
+            "affiliation": null
+          },
+          {
+            "family": "Silva",
+            "given": "Raniere",
+            "orcid": null,
+            "affiliation": null
+          },
+          {
+            "family": "Michonneau",
+            "given": "François",
+            "orcid": null,
+            "affiliation": null
+          },
+          {
+            "family": "Belkin",
+            "given": "Maxim",
+            "orcid": null,
+            "affiliation": null
+          },
+          {
+            "family": "Graham",
+            "given": "James",
+            "orcid": null,
+            "affiliation": null
+          },
+          {
+            "family": "Wilson",
+            "given": "Greg",
+            "orcid": null,
+            "affiliation": null
+          },
+          {
+            "family": "Bluteau",
+            "given": "Matthew",
+            "orcid": "0000-0001-9498-8475",
+            "affiliation": null
+          },
+          {
+            "family": "Hodges",
+            "given": "Toby",
+            "orcid": null,
+            "affiliation": null
+          },
+          {
+            "family": "Kamvar",
+            "given": "Zhian",
+            "orcid": null,
+            "affiliation": null
+          },
+          {
+            "family": "Burg",
+            "given": "Sven",
+            "orcid": "0000-0003-1250-6968",
+            "affiliation": null
+          },
+          {
+            "family": "Cabunoc Mayes",
+            "given": "Abby",
+            "orcid": null,
+            "affiliation": null
+          },
+          {
+            "family": "Robinson",
+            "given": "Martin",
+            "orcid": null,
+            "affiliation": null
+          },
+          {
+            "family": "Mangham",
+            "given": "Sam",
+            "orcid": null,
+            "affiliation": null
+          },
+          {
+            "family": "Laird",
+            "given": "Jacalyn",
+            "orcid": null,
+            "affiliation": null
+          },
+          {
+            "family": "Stevens",
+            "given": "Sarah",
+            "orcid": null,
+            "affiliation": null
+          },
+          {
+            "family": "Leinweber",
+            "given": "Katrin",
+            "orcid": null,
+            "affiliation": null
+          },
+          {
+            "family": "Becker",
+            "given": "Erin",
+            "orcid": null,
+            "affiliation": null
+          },
+          {
+            "family": "Rodrigues",
+            "given": "João",
+            "orcid": null,
+            "affiliation": null
+          },
+          {
+            "family": "Lowe",
+            "given": "Douglas",
+            "orcid": "0000-0002-1248-3594",
+            "affiliation": null
+          },
+          {
+            "family": "Goel",
+            "given": "Aman",
+            "orcid": null,
+            "affiliation": null
+          },
+          {
+            "family": "Graham",
+            "given": "Matthew M.",
+            "orcid": "0000-0001-9104-7960",
+            "affiliation": null
+          },
+          {
+            "family": "Gopinathan",
+            "given": "Devaraj",
+            "orcid": "0000-0002-0490-3229",
+            "affiliation": null
+          },
+          {
+            "family": "Camphuijsen",
+            "given": "Jaro",
+            "orcid": "0000-0002-8928-7831",
+            "affiliation": null
+          },
+          {
+            "family": "Crocioni",
+            "given": "Giulia",
+            "orcid": "0000-0002-0823-0121",
+            "affiliation": null
+          },
+          {
+            "family": "Close",
+            "given": "William",
+            "orcid": null,
+            "affiliation": null
+          },
+          {
+            "family": "Löffler",
+            "given": "Frank",
+            "orcid": null,
+            "affiliation": null
+          },
+          {
+            "family": "Rijn",
+            "given": "Sander",
+            "orcid": null,
+            "affiliation": null
+          },
+          {
+            "family": "Saunders",
+            "given": "Harry",
+            "orcid": null,
+            "affiliation": null
+          },
+          {
+            "family": "Field",
+            "given": "Matthew",
+            "orcid": null,
+            "affiliation": null
+          },
+          {
+            "family": "Gadgil",
+            "given": "Sanket",
+            "orcid": null,
+            "affiliation": null
+          },
+          {
+            "family": "Zarębski",
+            "given": "Kristian",
+            "orcid": null,
+            "affiliation": null
+          },
+          {
+            "family": "Collie",
+            "given": "Kingsley",
+            "orcid": null,
+            "affiliation": null
+          },
+          {
+            "family": "Neep",
+            "given": "Tom",
+            "orcid": null,
+            "affiliation": null
+          },
+          {
+            "family": "Alves",
+            "given": "Renato",
+            "orcid": null,
+            "affiliation": null
+          },
+          {
+            "family": "Katz",
+            "given": "Daniel",
+            "orcid": null,
+            "affiliation": null
+          },
+          {
+            "family": "Reeve",
+            "given": "Jen",
+            "orcid": null,
+            "affiliation": null
+          },
+          {
+            "family": "Murphy",
+            "given": "G.K.",
+            "orcid": null,
+            "affiliation": null
+          },
+          {
+            "family": "Sverchkov",
+            "given": "Yuriy",
+            "orcid": null,
+            "affiliation": null
+          },
+          {
+            "family": "Hartley",
+            "given": "S.",
+            "orcid": null,
+            "affiliation": null
+          },
+          {
+            "family": "Konovalov",
+            "given": "Olexandr",
+            "orcid": null,
+            "affiliation": null
+          },
+          {
+            "family": "Guyer",
+            "given": "Jonathan",
+            "orcid": null,
+            "affiliation": null
+          }
+        ]
+      }
+    },
+    "introduction-to-basic-statistics-with-r": {
+      "repoUrl": "https://github.com/ucdavisdatalab/basic_stats_r_1",
+      "stars": 0,
+      "forks": 0,
+      "openIssues": 0,
+      "pushedAt": "2021-02-18",
+      "updatedAt": "2021-02-18",
+      "contributorCount": 1,
+      "contributorCountTruncated": false,
+      "license": "GPL-3.0",
+      "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": false,
+      "citation": null
+    },
+    "introduction-to-desktop-gis-with-qgis": {
+      "repoUrl": "https://github.com/ucdavisdatalab/Intro-to-Desktop-GIS-with-QGIS",
+      "stars": 129,
+      "forks": 35,
+      "openIssues": 4,
+      "pushedAt": "2024-05-14",
+      "updatedAt": "2026-05-12",
+      "contributorCount": 5,
+      "contributorCountTruncated": false,
+      "license": "NOASSERTION",
+      "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": false,
+      "citation": null
+    },
+    "introduction-to-docker-for-research-note-this-is-now-called-introduction-to-docker-and-podman": {
+      "repoUrl": "https://github.com/hsf-training/hsf-training-docker",
       "stars": 3,
       "forks": 19,
       "openIssues": 11,
@@ -521,18 +1029,25 @@
       "contributorCountTruncated": false,
       "license": "NOASSERTION",
       "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": true,
       "citation": null
     },
-    "https://github.com/coderefinery/git-intro": {
+    "introduction-to-git": {
+      "repoUrl": "https://github.com/coderefinery/git-intro",
       "stars": 39,
       "forks": 76,
-      "openIssues": 39,
+      "openIssues": 40,
       "pushedAt": "2026-03-30",
       "updatedAt": "2026-05-18",
       "contributorCount": 24,
       "contributorCountTruncated": false,
       "license": "CC-BY-4.0",
       "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": false,
       "citation": {
         "source": "cff",
         "title": "Introduction to version control",
@@ -601,16 +1116,84 @@
         ]
       }
     },
-    "https://github.com/INTERSECT-training/Issue-Tracking": {
+    "introduction-to-remote-computing": {
+      "repoUrl": "https://github.com/ucdavisdatalab/workshop_intro_to_remote_computing",
+      "stars": 5,
+      "forks": 2,
+      "openIssues": 6,
+      "pushedAt": "2025-10-24",
+      "updatedAt": "2026-04-02",
+      "contributorCount": 4,
+      "contributorCountTruncated": false,
+      "license": "NOASSERTION",
+      "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": false,
+      "citation": null
+    },
+    "introduction-to-sql-for-querying-databases": {
+      "repoUrl": "https://github.com/ucdavisdatalab/workshop_intro_to_sql",
+      "stars": 24,
+      "forks": 7,
+      "openIssues": 3,
+      "pushedAt": "2024-10-24",
+      "updatedAt": "2025-01-03",
+      "contributorCount": 6,
+      "contributorCountTruncated": false,
+      "license": "NOASSERTION",
+      "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": false,
+      "citation": null
+    },
+    "introduction-to-unix-command-line": {
+      "repoUrl": "https://github.com/ucdavisdatalab/workshop_introduction_to_the_command_line",
+      "stars": 0,
+      "forks": 0,
+      "openIssues": 0,
+      "pushedAt": "2023-10-12",
+      "updatedAt": "2021-12-30",
+      "contributorCount": 3,
+      "contributorCountTruncated": false,
+      "license": "NOASSERTION",
+      "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": false,
+      "citation": null
+    },
+    "introduction-to-version-control-with-git": {
+      "repoUrl": "https://github.com/ucdavisdatalab/workshop_introduction_to_version_control",
+      "stars": 6,
+      "forks": 3,
+      "openIssues": 1,
+      "pushedAt": "2025-06-09",
+      "updatedAt": "2025-06-09",
+      "contributorCount": 4,
+      "contributorCountTruncated": false,
+      "license": "NOASSERTION",
+      "archived": true,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": false,
+      "citation": null
+    },
+    "issue-tracking-with-github": {
+      "repoUrl": "https://github.com/INTERSECT-training/Issue-Tracking",
       "stars": 0,
       "forks": 1,
       "openIssues": 1,
-      "pushedAt": "2026-05-19",
+      "pushedAt": "2026-05-26",
       "updatedAt": "2025-09-18",
       "contributorCount": 3,
       "contributorCountTruncated": false,
       "license": "NOASSERTION",
       "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": true,
       "citation": {
         "source": "cff",
         "title": "INTERSECT: Issue Tracking",
@@ -628,16 +1211,52 @@
         ]
       }
     },
-    "https://github.com/INTERSECT-training/Making-Good-PRs": {
+    "julia-basics": {
+      "repoUrl": "https://github.com/ucjug/workshop_julia_basics",
+      "stars": 1,
+      "forks": 2,
+      "openIssues": 0,
+      "pushedAt": "2024-02-12",
+      "updatedAt": "2025-07-31",
+      "contributorCount": 3,
+      "contributorCountTruncated": false,
+      "license": "NOASSERTION",
+      "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": false,
+      "citation": null
+    },
+    "leadership-and-governance": {
+      "repoUrl": "https://github.com/github/opensource.guide",
+      "stars": 15465,
+      "forks": 15393,
+      "openIssues": 9,
+      "pushedAt": "2026-05-21",
+      "updatedAt": "2026-05-26",
+      "contributorCount": 100,
+      "contributorCountTruncated": true,
+      "license": "CC-BY-4.0",
+      "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": true,
+      "citation": null
+    },
+    "making-good-pull-requests": {
+      "repoUrl": "https://github.com/INTERSECT-training/Making-Good-PRs",
       "stars": 0,
       "forks": 1,
       "openIssues": 0,
-      "pushedAt": "2026-05-19",
+      "pushedAt": "2026-05-26",
       "updatedAt": "2025-09-18",
       "contributorCount": 3,
       "contributorCountTruncated": false,
       "license": "NOASSERTION",
       "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": true,
       "citation": {
         "source": "cff",
         "title": "INTERSECT: Making Good Pull Requests",
@@ -655,7 +1274,24 @@
         ]
       }
     },
-    "https://github.com/coderefinery/modular-type-along": {
+    "metrics": {
+      "repoUrl": "https://github.com/github/opensource.guide",
+      "stars": 15465,
+      "forks": 15393,
+      "openIssues": 9,
+      "pushedAt": "2026-05-21",
+      "updatedAt": "2026-05-26",
+      "contributorCount": 100,
+      "contributorCountTruncated": true,
+      "license": "CC-BY-4.0",
+      "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": true,
+      "citation": null
+    },
+    "modular-programming-with-python": {
+      "repoUrl": "https://github.com/coderefinery/modular-type-along",
       "stars": 4,
       "forks": 9,
       "openIssues": 9,
@@ -665,6 +1301,9 @@
       "contributorCountTruncated": false,
       "license": "CC-BY-4.0",
       "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": false,
       "citation": {
         "source": "cff",
         "title": "Modular code development type-along",
@@ -721,7 +1360,57 @@
         ]
       }
     },
-    "https://github.com/MolSSI-Education/python-package-best-practices": {
+    "overview-of-databases-and-data-storage": {
+      "repoUrl": "https://github.com/ucdavisdatalab/workshop_intro_to_databases",
+      "stars": 0,
+      "forks": 0,
+      "openIssues": 3,
+      "pushedAt": "2025-08-14",
+      "updatedAt": "2025-08-14",
+      "contributorCount": 1,
+      "contributorCountTruncated": false,
+      "license": "NOASSERTION",
+      "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": false,
+      "citation": null
+    },
+    "overview-of-remote-and-high-performance-computing-hpc": null,
+    "principles-of-data-visualization-from-perception-to-statistical-graphics": {
+      "repoUrl": "https://github.com/ucdavisdatalab/workshop_data_viz_principles",
+      "stars": 0,
+      "forks": 0,
+      "openIssues": 1,
+      "pushedAt": "2023-09-21",
+      "updatedAt": "2023-08-03",
+      "contributorCount": 3,
+      "contributorCountTruncated": false,
+      "license": "NOASSERTION",
+      "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": false,
+      "citation": null
+    },
+    "python-basics": {
+      "repoUrl": "https://github.com/ucdavisdatalab/workshop_python_basics",
+      "stars": 7,
+      "forks": 4,
+      "openIssues": 4,
+      "pushedAt": "2025-06-11",
+      "updatedAt": "2025-12-01",
+      "contributorCount": 4,
+      "contributorCountTruncated": false,
+      "license": "NOASSERTION",
+      "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": false,
+      "citation": null
+    },
+    "python-package-development-best-practices": {
+      "repoUrl": "https://github.com/MolSSI-Education/python-package-best-practices",
       "stars": 44,
       "forks": 34,
       "openIssues": 1,
@@ -731,6 +1420,9 @@
       "contributorCountTruncated": false,
       "license": "NOASSERTION",
       "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": false,
       "citation": {
         "source": "cff",
         "title": "Best Practices in Python Package Development (Version 2021.08.0)",
@@ -796,16 +1488,20 @@
         ]
       }
     },
-    "https://github.com/INTERSECT-training/packaging": {
+    "python-packaging-for-beginners": {
+      "repoUrl": "https://github.com/INTERSECT-training/packaging",
       "stars": 4,
       "forks": 4,
       "openIssues": 6,
-      "pushedAt": "2026-05-19",
+      "pushedAt": "2026-05-26",
       "updatedAt": "2025-10-01",
       "contributorCount": 9,
       "contributorCountTruncated": false,
       "license": "NOASSERTION",
       "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": true,
       "citation": {
         "source": "cff",
         "title": "INTERSECT: Packaging",
@@ -847,7 +1543,8 @@
         ]
       }
     },
-    "https://github.com/carpentries-incubator/python_packaging": {
+    "python-packaging": {
+      "repoUrl": "https://github.com/carpentries-incubator/python_packaging",
       "stars": 6,
       "forks": 6,
       "openIssues": 1,
@@ -857,18 +1554,41 @@
       "contributorCountTruncated": false,
       "license": "NOASSERTION",
       "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": true,
       "citation": null
     },
-    "https://github.com/carpentries-incubator/lesson-R-packaging": {
+    "r-basics": {
+      "repoUrl": "https://github.com/ucdavisdatalab/workshop_r_basics",
+      "stars": 1,
+      "forks": 2,
+      "openIssues": 6,
+      "pushedAt": "2026-03-17",
+      "updatedAt": "2026-03-17",
+      "contributorCount": 2,
+      "contributorCountTruncated": false,
+      "license": "NOASSERTION",
+      "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": false,
+      "citation": null
+    },
+    "r-packaging": {
+      "repoUrl": "https://github.com/carpentries-incubator/lesson-R-packaging",
       "stars": 5,
       "forks": 10,
       "openIssues": 27,
-      "pushedAt": "2026-05-19",
+      "pushedAt": "2026-05-26",
       "updatedAt": "2025-09-17",
       "contributorCount": 8,
       "contributorCountTruncated": false,
       "license": "NOASSERTION",
       "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": true,
       "citation": {
         "source": "cff",
         "title": "lesson-R-packaging",
@@ -898,19 +1618,68 @@
         ]
       }
     },
-    "https://github.com/carpentries-incubator/docker-introduction": {
+    "reproducible-computational-environments-using-containers": {
+      "repoUrl": "https://github.com/carpentries-incubator/docker-introduction",
       "stars": 53,
-      "forks": 52,
+      "forks": 53,
       "openIssues": 47,
-      "pushedAt": "2026-05-19",
+      "pushedAt": "2026-05-26",
       "updatedAt": "2026-01-14",
       "contributorCount": 62,
       "contributorCountTruncated": false,
       "license": "NOASSERTION",
       "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": true,
       "citation": null
     },
-    "https://github.com/alan-turing-institute/rse-course": {
+    "reproducible-research-for-teams-with-github": {
+      "repoUrl": "https://github.com/ucdavisdatalab/workshop_git_for_teams",
+      "stars": 2,
+      "forks": 2,
+      "openIssues": 0,
+      "pushedAt": "2025-06-09",
+      "updatedAt": "2025-06-09",
+      "contributorCount": 5,
+      "contributorCountTruncated": false,
+      "license": "NOASSERTION",
+      "archived": true,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": false,
+      "citation": null
+    },
+    "reproducible-research": {
+      "repoUrl": "https://github.com/the-turing-way/the-turing-way",
+      "stars": 2148,
+      "forks": 749,
+      "openIssues": 607,
+      "pushedAt": "2026-05-25",
+      "updatedAt": "2026-05-26",
+      "contributorCount": 100,
+      "contributorCountTruncated": true,
+      "license": "NOASSERTION",
+      "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": true,
+      "citation": {
+        "source": "cff",
+        "title": "The Turing Way handbook for reproducible, ethical and collaborative research",
+        "doi": "10.5281/zenodo.3233853",
+        "version": "1.2.3",
+        "dateReleased": "2025-04-14",
+        "license": "CC-BY-4.0",
+        "authors": [
+          {
+            "name": "The Turing Way Community"
+          }
+        ]
+      }
+    },
+    "research-software-engineering-with-python-course": {
+      "repoUrl": "https://github.com/alan-turing-institute/rse-course",
       "stars": 264,
       "forks": 122,
       "openIssues": 46,
@@ -920,9 +1689,29 @@
       "contributorCountTruncated": false,
       "license": "NOASSERTION",
       "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": false,
       "citation": null
     },
-    "https://github.com/coderefinery/social-coding": {
+    "responsible-data-science": {
+      "repoUrl": "https://github.com/ucdavisdatalab/responsible-data-science",
+      "stars": 0,
+      "forks": 0,
+      "openIssues": 0,
+      "pushedAt": "2023-02-16",
+      "updatedAt": "2023-02-15",
+      "contributorCount": 3,
+      "contributorCountTruncated": false,
+      "license": "NOASSERTION",
+      "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": false,
+      "citation": null
+    },
+    "social-coding-and-open-source-collaboration": {
+      "repoUrl": "https://github.com/coderefinery/social-coding",
       "stars": 9,
       "forks": 16,
       "openIssues": 14,
@@ -932,6 +1721,9 @@
       "contributorCountTruncated": false,
       "license": "CC-BY-4.0",
       "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": false,
       "citation": {
         "source": "cff",
         "title": "Social coding and open software - What can you do to get credit for your code and allow reuse?",
@@ -1000,7 +1792,40 @@
         ]
       }
     },
-    "https://github.com/coderefinery/testing": {
+    "spatial-sql-with-spatialite": {
+      "repoUrl": "https://github.com/ucdavisdatalab/Spatial_SQL",
+      "stars": 35,
+      "forks": 16,
+      "openIssues": 3,
+      "pushedAt": "2026-04-24",
+      "updatedAt": "2026-04-24",
+      "contributorCount": 3,
+      "contributorCountTruncated": false,
+      "license": "NOASSERTION",
+      "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": false,
+      "citation": null
+    },
+    "starting-an-open-source-project": {
+      "repoUrl": "https://github.com/github/opensource.guide",
+      "stars": 15465,
+      "forks": 15393,
+      "openIssues": 9,
+      "pushedAt": "2026-05-21",
+      "updatedAt": "2026-05-26",
+      "contributorCount": 100,
+      "contributorCountTruncated": true,
+      "license": "CC-BY-4.0",
+      "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": true,
+      "citation": null
+    },
+    "testing-and-test-driven-development": {
+      "repoUrl": "https://github.com/coderefinery/testing",
       "stars": 12,
       "forks": 41,
       "openIssues": 16,
@@ -1010,6 +1835,9 @@
       "contributorCountTruncated": false,
       "license": "CC-BY-4.0",
       "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": false,
       "citation": {
         "source": "cff",
         "title": "Automated testing",
@@ -1120,40 +1948,68 @@
         ]
       }
     },
-    "https://github.com/INTERSECT-training/software-licensing": {
+    "understanding-software-licensing": {
+      "repoUrl": "https://github.com/INTERSECT-training/software-licensing",
       "stars": 0,
       "forks": 4,
       "openIssues": 8,
-      "pushedAt": "2026-05-19",
+      "pushedAt": "2026-05-26",
       "updatedAt": "2025-09-17",
       "contributorCount": 4,
       "contributorCountTruncated": false,
       "license": "NOASSERTION",
       "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": true,
       "citation": null
     },
-    "https://github.com/INTERSECT-training/testing": {
+    "unit-testing-and-tdd-in-python": {
+      "repoUrl": "https://github.com/INTERSECT-training/testing",
       "stars": 0,
       "forks": 3,
       "openIssues": 1,
-      "pushedAt": "2026-05-19",
+      "pushedAt": "2026-05-26",
       "updatedAt": "2025-09-17",
       "contributorCount": 7,
       "contributorCountTruncated": false,
       "license": "NOASSERTION",
       "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": true,
       "citation": null
     },
-    "https://github.com/INTERSECT-training/Documentation": {
+    "what-is-open-source": {
+      "repoUrl": "https://github.com/github/opensource.guide",
+      "stars": 15465,
+      "forks": 15393,
+      "openIssues": 9,
+      "pushedAt": "2026-05-21",
+      "updatedAt": "2026-05-26",
+      "contributorCount": 100,
+      "contributorCountTruncated": true,
+      "license": "CC-BY-4.0",
+      "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": true,
+      "citation": null
+    },
+    "writing-documentation-for-software-projects": {
+      "repoUrl": "https://github.com/INTERSECT-training/Documentation",
       "stars": 0,
       "forks": 2,
       "openIssues": 1,
-      "pushedAt": "2026-05-19",
+      "pushedAt": "2026-05-26",
       "updatedAt": "2025-09-18",
       "contributorCount": 3,
       "contributorCountTruncated": false,
       "license": "NOASSERTION",
       "archived": false,
+      "sponsorsUrl": null,
+      "hasFunding": false,
+      "hasCodeOfConduct": true,
       "citation": {
         "source": "cff",
         "title": "INTERSECT: Better Documentation",
@@ -1171,16 +2027,20 @@
         ]
       }
     },
-    "https://github.com/firstcontributions/first-contributions": {
-      "stars": 54126,
-      "forks": 103032,
-      "openIssues": 104,
-      "pushedAt": "2026-05-24",
-      "updatedAt": "2026-05-24",
+    "your-first-web-contribution": {
+      "repoUrl": "https://github.com/firstcontributions/first-contributions",
+      "stars": 54181,
+      "forks": 103145,
+      "openIssues": 79,
+      "pushedAt": "2026-05-26",
+      "updatedAt": "2026-05-26",
       "contributorCount": 100,
       "contributorCountTruncated": true,
       "license": "MIT",
       "archived": false,
+      "sponsorsUrl": "https://github.com/sponsors/firstcontributions",
+      "hasFunding": true,
+      "hasCodeOfConduct": true,
       "citation": null
     }
   }

--- a/src/lib/githubHealth.ts
+++ b/src/lib/githubHealth.ts
@@ -13,6 +13,7 @@ export type Citation = {
 };
 
 export type HealthRecord = {
+  repoUrl: string;
   stars: number;
   forks: number;
   openIssues: number;
@@ -22,10 +23,13 @@ export type HealthRecord = {
   contributorCountTruncated: boolean;
   license: string | null;
   archived: boolean;
+  sponsorsUrl: string | null;
+  hasFunding: boolean;
+  hasCodeOfConduct: boolean;
   citation: Citation | null;
 };
 
 export type HealthSnapshot = {
   fetchedAt: string | null;
-  lessons: Record<string, HealthRecord>;
+  lessons: Record<string, HealthRecord | null>;
 };

--- a/src/pages/api/lessons.json.ts
+++ b/src/pages/api/lessons.json.ts
@@ -14,7 +14,7 @@ export const GET: APIRoute = async () => {
     .filter((l) => l.keepStatus !== 'drop')
     .sort((a, b) => a.name.localeCompare(b.name))
     .map((l) => {
-      const health = l.repoUrl ? healthLessons[l.repoUrl] ?? null : null;
+      const health = healthLessons[l.slug] ?? null;
       return {
         name: l.name,
         slug: l.slug,
@@ -40,6 +40,10 @@ export const GET: APIRoute = async () => {
               contributors: health.contributorCount ?? null,
               openIssues: health.openIssues ?? 0,
               archived: health.archived ?? false,
+              license: health.license ?? null,
+              sponsorsUrl: health.sponsorsUrl ?? null,
+              hasFunding: health.hasFunding ?? false,
+              hasCodeOfConduct: health.hasCodeOfConduct ?? false,
               citation: health.citation ?? null,
               fetchedAt: healthData.fetchedAt ?? null,
             }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,9 +4,15 @@ import WelcomeHeader from '../components/home/WelcomeHeader.astro';
 import BrowseAllLessonsPanel from '../components/home/BrowseAllLessonsPanel.astro';
 import PathwayShowcase from '../components/home/PathwayShowcase';
 import '../components/home/home.css';
+import '../components/lessons/lessons.css';
 import { getCollection } from 'astro:content';
 import { getActiveLessons, type Lesson } from '../lib/lessons';
+import githubHealthRaw from '../data/github-health.json';
+import type { HealthSnapshot } from '../lib/githubHealth';
 import type { CategoryIconName, HomepagePathwayItem, HomepagePathwaySection } from '../components/home/types';
+
+const healthData = githubHealthRaw as unknown as HealthSnapshot;
+const healthBySlug = healthData.lessons ?? {};
 
 const [activeLessons, pathways] = await Promise.all([
   getActiveLessons(),
@@ -65,7 +71,7 @@ const defaultHomepagePathwayId =
 
     <section class="home-showcase" aria-labelledby="pathways-heading">
       <h2 id="pathways-heading" class="sr-only">Learning pathways</h2>
-      <PathwayShowcase items={homepagePathways} defaultActiveId={defaultHomepagePathwayId} client:load />
+      <PathwayShowcase items={homepagePathways} defaultActiveId={defaultHomepagePathwayId} healthBySlug={healthBySlug} client:load />
       <BrowseAllLessonsPanel />
     </section>
   </div>

--- a/src/pages/lessons.astro
+++ b/src/pages/lessons.astro
@@ -2,9 +2,13 @@
 import BaseLayout from "../layouts/BaseLayout.astro";
 import LessonFilter from "../components/LessonFilter.tsx";
 import { getActiveLessons } from "../lib/lessons";
+import githubHealthRaw from "../data/github-health.json";
+import type { HealthSnapshot } from "../lib/githubHealth";
 import "../components/lessons/lessons.css";
 
 const activeLessons = await getActiveLessons();
+const healthData = githubHealthRaw as unknown as HealthSnapshot;
+const healthBySlug = healthData.lessons ?? {};
 ---
 
 <BaseLayout
@@ -30,6 +34,6 @@ const activeLessons = await getActiveLessons();
       </div>
     </div>
   ) : (
-    <LessonFilter lessons={activeLessons} client:load />
+    <LessonFilter lessons={activeLessons} healthBySlug={healthBySlug} client:load />
   )}
 </BaseLayout>

--- a/src/pages/lessons/[slug].astro
+++ b/src/pages/lessons/[slug].astro
@@ -50,9 +50,7 @@ const pathwayHref = pathwayId ? `${import.meta.env.BASE_URL}pathways/${pathwayId
 const summary = lesson.description?.trim() || lesson.abstract?.trim() || "";
 const externalHref = lesson.url?.trim() ?? "";
 
-const repoHealth = lesson.repoUrl
-  ? (healthData.lessons[lesson.repoUrl] ?? null)
-  : null;
+const repoHealth = healthData.lessons[lesson.slug] ?? null;
 const repoLastUpdated = repoHealth?.pushedAt ?? null;
 
 const catalogCitation = getCatalogCitation();

--- a/src/pages/pathways/[id].astro
+++ b/src/pages/pathways/[id].astro
@@ -3,7 +3,11 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
 import { getLessons, type Lesson } from "../../lib/lessons";
 import { getCollection } from "astro:content";
 import LessonCard from "../../components/LessonCard.jsx";
+import githubHealthRaw from "../../data/github-health.json";
+import type { HealthSnapshot } from "../../lib/githubHealth";
 import "../../components/lessons/lessons.css";
+
+const healthData = githubHealthRaw as unknown as HealthSnapshot;
 
 interface Props {
   id: string;
@@ -116,6 +120,7 @@ const groupedLessons = pathwayLessons.reduce<Record<string, Lesson[]>>((acc, les
               <LessonCard
                 lesson={lesson}
                 lessonIndex={lessonIndex}
+                health={healthData.lessons[lesson.slug] ?? null}
                 headingLevel={3}
                 client:load
               />

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -74,6 +74,15 @@ const pagefindCss = `${pagefindPath}pagefind-component-ui.css`;
   (async () => {
     const el = document.getElementById("search");
     if (!el) return;
+    const searchInputLabel =
+      "Search lessons, pathways, and resources in this catalog";
+
+    function ensureSearchInputAccessibleName() {
+      const input = el.querySelector(".pf-searchbox-input");
+      if (!input || input.getAttribute("aria-label")) return;
+      input.setAttribute("aria-label", searchInputLabel);
+    }
+
     try {
       // Load the Component UI — registers web components including
       // <pagefind-config> and <pagefind-searchbox>
@@ -87,6 +96,20 @@ const pagefindCss = `${pagefindPath}pagefind-component-ui.css`;
       el.innerHTML =
         `<pagefind-config bundle-path="${pagefindPath}" base-url="${base}"></pagefind-config>` +
         `<pagefind-searchbox autofocus></pagefind-searchbox>`;
+
+      // Pagefind's combobox input only sets a placeholder; Pa11y (and WCAG)
+      // expect an accessible name on the control.
+      try {
+        await customElements.whenDefined("pagefind-searchbox");
+      } catch {
+        // ignore — labelling still runs via MutationObserver below
+      }
+      ensureSearchInputAccessibleName();
+      const searchBox = el.querySelector("pagefind-searchbox");
+      if (searchBox) {
+        const observer = new MutationObserver(() => ensureSearchInputAccessibleName());
+        observer.observe(searchBox, { childList: true, subtree: true });
+      }
     } catch {
       el.innerHTML =
         '<p class="search-unavailable">Search index not found — run <code>npm run build</code> to generate it.</p>';


### PR DESCRIPTION
## Summary

This PR adds GitHub community health signals to lesson cards and automates quarterly staleness review for maintainers — the user-facing layer (#118) and the governance layer (#128).

### GitHub health signals on lesson cards (#118)

- **`scripts/fetch-github-health.mjs`** now builds a slug-keyed snapshot for every lesson, parsing GitHub repos from `repoUrl` or `url` (including `github.com` and `*.github.io`), deduplicating shared repos, and fetching stars, forks, contributors, last push, license, `FUNDING.yml`, Code of Conduct, and CITATION.cff data.
- **`src/data/github-health.json`** is keyed by lesson slug (not repo URL) and committed so builds stay static and API-free.
- **`HealthSignalRow`** renders a compact signal row: ⭐ (links to repo), 🍴, 👥, relative last-updated (amber when >18 months), license, 💚 Sponsorable, and 🤝 CoC — with accessible labels and graceful omission when data is missing.
- **Wired into:** `/lessons/`, pathway pages, homepage preview cards, lesson detail pages (citation / last-updated), and `api/lessons.json`.
- **Card structure** refactored to `<article>` + cover link so star/sponsor links work without blocking card navigation.
- **`.github/workflows/refresh-github-health.yml`** refreshes health data weekly, on lesson JSON changes, and via manual dispatch; commits only when the snapshot changes (`[skip ci]`).

### Staleness detection workflow (#128)

- **`.github/workflows/staleness-check.yml`** runs quarterly (1st of Jan/Apr/Jul/Oct, 9:00 UTC) and via `workflow_dispatch`.
- Opens one **`stale-lesson`** issue per lesson whose `dateModified` (or `dateCreated`) is >18 months old, using the same month-based threshold as the card UI.
- Skips `keepStatus: drop` and `creativeWorkStatus: Archived` lessons; dedupes against existing open issues; includes review checklist, lesson link, external URL, and optional `campusOwner`.
- **`stale-lesson`** label created (`#fbca04`).

### Other fixes included

- Search page: Pagefind combobox gets an accessible name (Pa11y/axe).
- Footer legal links use theme tokens for light/dark consistency.


closes #118 
closes #128
