### PR TITLE
feat(lessons-filter): pathway names, learning-type definitions, drop dead dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@keystatic/astro": "^5.0.6",
         "@keystatic/core": "^0.5.48",
         "astro": "^5.13.8",
-        "fuse.js": "^7.1.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
       },
@@ -8193,15 +8192,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/fuse.js": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmmirror.com/fuse.js/-/fuse.js-7.1.0.tgz",
-      "integrity": "sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/generator-function": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "@keystatic/astro": "^5.0.6",
     "@keystatic/core": "^0.5.48",
     "astro": "^5.13.8",
-    "fuse.js": "^7.1.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   },

--- a/src/components/LessonFilter.tsx
+++ b/src/components/LessonFilter.tsx
@@ -7,6 +7,19 @@ interface LessonFilterProps {
   lessons: Lesson[];
   healthBySlug?: Record<string, HealthRecord | null>;
   pagefindPath: string;
+  pathwayNames?: Record<string, string>;
+}
+
+// learningResourceType is free text in schema.org, so we define our own values.
+// Surfaced via the (i) help toggle on the Learning Type filter.
+const TYPE_DEFINITIONS: Record<string, string> = {
+  guide: "Self-study reading or reference, worked through at your own pace.",
+  workshop: "Hands-on and designed to be taught, with active exercises.",
+  course: "A structured, multi-part curriculum, often taught over several sessions.",
+};
+
+function titleCase(value: string): string {
+  return value.replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
 type PagefindResult = { data: () => Promise<{ url: string }> };
@@ -47,11 +60,12 @@ function splitAudience(audience: string) {
   return audience.split(",").map((item) => item.trim()).filter(Boolean);
 }
 
-export default function LessonFilter({ lessons, healthBySlug = {}, pagefindPath }: LessonFilterProps) {
+export default function LessonFilter({ lessons, healthBySlug = {}, pagefindPath, pathwayNames = {} }: LessonFilterProps) {
   const [isLoading, setIsLoading] = useState(true);
   const [isSearching, setIsSearching] = useState(false);
   const [searchSlugs, setSearchSlugs] = useState<Set<string> | null>(null);
   const [filters, setFilters] = useState(getInitialFilters);
+  const [showTypeHelp, setShowTypeHelp] = useState(false);
 
   const pagefindRef = useRef<PagefindModule | null>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -263,7 +277,7 @@ export default function LessonFilter({ lessons, healthBySlug = {}, pagefindPath 
             >
               <option value="">All Pathways</option>
               {filterOptions.pathways.map((p) => (
-                <option key={p} value={p}>{p}</option>
+                <option key={p} value={p}>{pathwayNames[p] ?? titleCase(p.replace(/-/g, " "))}</option>
               ))}
             </select>
           </div>
@@ -284,7 +298,29 @@ export default function LessonFilter({ lessons, healthBySlug = {}, pagefindPath 
           </div>
 
           <div className="lessons-filter__field">
-            <label htmlFor="lesson-type" className="lessons-filter__label">Learning Type</label>
+            <span className="lessons-filter__label-row">
+              <label htmlFor="lesson-type" className="lessons-filter__label">Learning Type</label>
+              <button
+                type="button"
+                className="lessons-filter__help-toggle"
+                aria-expanded={showTypeHelp}
+                aria-controls="lesson-type-help"
+                aria-label="What do the learning types mean?"
+                onClick={() => setShowTypeHelp((v) => !v)}
+              >
+                <span aria-hidden="true">ⓘ</span>
+              </button>
+            </span>
+            {showTypeHelp && (
+              <dl id="lesson-type-help" className="lessons-filter__help">
+                {Object.entries(TYPE_DEFINITIONS).map(([term, def]) => (
+                  <div key={term} className="lessons-filter__help-item">
+                    <dt>{titleCase(term)}</dt>
+                    <dd>{def}</dd>
+                  </div>
+                ))}
+              </dl>
+            )}
             <select
               id="lesson-type"
               className="lessons-filter__select"
@@ -293,7 +329,7 @@ export default function LessonFilter({ lessons, healthBySlug = {}, pagefindPath 
             >
               <option value="">All Types</option>
               {filterOptions.types.map((type) => (
-                <option key={type} value={type}>{type}</option>
+                <option key={type} value={type}>{titleCase(type)}</option>
               ))}
             </select>
           </div>

--- a/src/components/lessons/lessons.css
+++ b/src/components/lessons/lessons.css
@@ -38,6 +38,56 @@
   color: var(--text-secondary);
 }
 
+.lessons-filter__label-row {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.lessons-filter__help-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.1rem;
+  height: 1.1rem;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  background: none;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.lessons-filter__help-toggle:hover {
+  color: var(--uc-blue);
+}
+
+.lessons-filter__help {
+  margin: 0 0 0.2rem;
+  padding: 0.6rem 0.75rem;
+  border-radius: var(--radius-md);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-light);
+  font-size: 0.78rem;
+  line-height: 1.4;
+}
+
+.lessons-filter__help-item + .lessons-filter__help-item {
+  margin-top: 0.4rem;
+}
+
+.lessons-filter__help dt {
+  font-weight: 600;
+  color: var(--uc-blue);
+}
+
+.lessons-filter__help dd {
+  margin: 0;
+  color: var(--text-secondary);
+}
+
 .lessons-filter__input,
 .lessons-filter__select {
   width: 100%;

--- a/src/pages/lessons.astro
+++ b/src/pages/lessons.astro
@@ -2,6 +2,7 @@
 import BaseLayout from "../layouts/BaseLayout.astro";
 import LessonFilter from "../components/LessonFilter.tsx";
 import { getActiveLessons } from "../lib/lessons";
+import { getCollection } from "astro:content";
 import githubHealthRaw from "../data/github-health.json";
 import type { HealthSnapshot } from "../lib/githubHealth";
 import "../components/lessons/lessons.css";
@@ -10,6 +11,11 @@ const activeLessons = await getActiveLessons();
 const healthData = githubHealthRaw as unknown as HealthSnapshot;
 const healthBySlug = healthData.lessons ?? {};
 const pagefindPath = `${import.meta.env.BASE_URL}pagefind/`;
+
+// Map pathway slug -> display name so the filter shows "Building Inclusive
+// Communities" rather than the raw "building-communities" slug.
+const pathways = await getCollection("pathways");
+const pathwayNames = Object.fromEntries(pathways.map((p) => [p.id, p.data.name]));
 ---
 
 <BaseLayout
@@ -35,6 +41,6 @@ const pagefindPath = `${import.meta.env.BASE_URL}pagefind/`;
       </div>
     </div>
   ) : (
-    <LessonFilter lessons={activeLessons} healthBySlug={healthBySlug} pagefindPath={pagefindPath} client:load />
+    <LessonFilter lessons={activeLessons} healthBySlug={healthBySlug} pagefindPath={pagefindPath} pathwayNames={pathwayNames} client:load />
   )}
 </BaseLayout>


### PR DESCRIPTION
Three low-risk filter improvements from the IA review (no taxonomy/data changes, no committee decisions required).

## Changes
- **Pathway filter shows display names** instead of raw slugs (e.g. "Building Inclusive Communities" not `building-communities`), via a slug→name map passed from the pathways collection.
- **Learning Type: Title-Case labels + an accessible (i) help toggle** defining guide / workshop / course. `learningResourceType` is free text in schema.org with no controlled vocabulary, so we define the terms for users. Toggle uses `aria-expanded` / `aria-controls`.
- **Removed the unused `fuse.js` dependency** (search is handled by Pagefind; fuse was imported nowhere in `src/`).

## Verification
- `astro build` passes (80 pages)
- ESLint clean on `LessonFilter.tsx`
- `fuse` removed from `package.json` and `package-lock.json`

Part of the broader IA/taxonomy work; the larger items (intent badges, topic/audience re-tagging, multi-select filters) are intentionally not in this PR.