### PR TITLE
feat(provenance): curated vs created badge + JSON-LD provenance (#144)

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -1274,6 +1274,18 @@ a.lesson-badge--provider:hover {
   border-color: rgba(0, 129, 85, 0.4);
 }
 
+.lesson-badge--created {
+  background: rgba(0, 85, 129, 0.1);
+  color: var(--uc-dark-blue);
+  border-color: rgba(0, 85, 129, 0.3);
+}
+
+.lesson-badge--curated {
+  background: var(--bg-surface-strong);
+  color: var(--text-secondary);
+  border-color: var(--border-light);
+}
+
 .lesson-detail-row--provider {
   align-items: flex-start;
 }

--- a/src/components/LessonCard.jsx
+++ b/src/components/LessonCard.jsx
@@ -6,6 +6,7 @@ const TYPE_ICONS = {
   course:   AcademicCapIcon,
 };
 import HealthSignalRow from "./HealthSignalRow.jsx";
+import { isCreatedByUs } from "../lib/provenance";
 
 /** @typedef {import("../lib/githubHealth").HealthRecord} HealthRecord */
 
@@ -52,6 +53,7 @@ export default function LessonCard({ lesson, lessonIndex = {}, headingLevel = 3,
   const TypeIcon = TYPE_ICONS[lesson.learningResourceType?.toLowerCase()] ?? null;
   const roleTags = (lesson.roles ?? []).slice(0, 2);
   const duration = formatDuration(lesson.timeRequired);
+  const createdByUs = isCreatedByUs(lesson);
 
   const prerequisiteLinks = (lesson.prerequisites ?? [])
     .map((prereq) => {
@@ -98,6 +100,12 @@ export default function LessonCard({ lesson, lessonIndex = {}, headingLevel = 3,
         <p className="lesson-card__meta-type">
           {TypeIcon && <TypeIcon className="lesson-card__meta-type-icon" aria-hidden="true" />}
           {topMeta}
+          <span
+            className={`lesson-card__provenance lesson-card__provenance--${createdByUs ? "created" : "curated"}`}
+            title={createdByUs ? "Created by the UC OSPO Network" : "An external resource curated by the UC OSPO Network"}
+          >
+            {createdByUs ? "Created" : "Curated"}
+          </span>
         </p>
         {roleTags.length > 0 && (
           <p className="lesson-card__meta-role">{roleTags.join(", ")}</p>

--- a/src/components/LessonJsonLd.astro
+++ b/src/components/LessonJsonLd.astro
@@ -1,5 +1,6 @@
 ---
 import type { Lesson } from "../lib/lessons";
+import { isCreatedByUs, CREATOR_ORG } from "../lib/provenance";
 import { getCollection } from "astro:content";
 
 interface Props {
@@ -8,6 +9,7 @@ interface Props {
 }
 
 const { lesson, canonicalUrl } = Astro.props as Props;
+const createdByUs = isCreatedByUs(lesson);
 
 const pathways = await getCollection("pathways");
 const pathwayMap = Object.fromEntries(pathways.map((p) => [p.id, p.data.name]));
@@ -37,11 +39,32 @@ if (nonEmpty(lesson.license)) data.license = lesson.license;
 if (nonEmpty(lesson.author)) data.author = { "@type": "Person", name: lesson.author };
 if (nonEmpty(lesson.learningObjectives)) data.teaches = lesson.learningObjectives;
 
+// Provenance: we always publish the structured data (sdPublisher). For curated
+// external resources, point sameAs at the canonical source and credit the
+// source provider as publisher; for resources we created, we are the publisher.
+data.sdPublisher = { "@type": "Organization", name: CREATOR_ORG };
+if (createdByUs) {
+  data.publisher = { "@type": "Organization", name: CREATOR_ORG };
+} else {
+  if (nonEmpty(lesson.url)) data.sameAs = lesson.url;
+  if (nonEmpty(lesson.provider)) data.publisher = { "@type": "Organization", name: lesson.provider };
+}
+
+// Intended educational role (schema.org): guides are for self-study (student);
+// taught formats serve both learners and instructors.
+const taught = ["workshop", "course"].includes((lesson.learningResourceType ?? "").toLowerCase());
+const educationalAudience = [
+  { "@type": "EducationalAudience", educationalRole: "student" },
+  ...(taught ? [{ "@type": "EducationalAudience", educationalRole: "teacher" }] : []),
+];
+
 if (lesson.roles.length > 0) {
-  data.audience = lesson.roles.map((role) => ({
-    "@type": "Audience",
-    audienceType: role,
-  }));
+  data.audience = [
+    ...educationalAudience,
+    ...lesson.roles.map((role) => ({ "@type": "Audience", audienceType: role })),
+  ];
+} else {
+  data.audience = educationalAudience;
 }
 
 if (lesson.pathways.length > 0) {

--- a/src/components/lessons/lessons.css
+++ b/src/components/lessons/lessons.css
@@ -206,6 +206,28 @@
   color: var(--text-secondary);
 }
 
+.lesson-card__provenance {
+  margin-left: auto;
+  padding: 0.1rem 0.5rem;
+  border-radius: var(--radius-pill);
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  border: 1px solid transparent;
+}
+
+.lesson-card__provenance--created {
+  background: rgba(0, 85, 129, 0.1);
+  color: var(--uc-dark-blue);
+  border-color: rgba(0, 85, 129, 0.3);
+}
+
+.lesson-card__provenance--curated {
+  background: var(--bg-surface-strong);
+  color: var(--text-secondary);
+  border-color: var(--border-light);
+}
+
 .lesson-card__meta-type-icon {
   width: 0.85rem;
   height: 0.85rem;

--- a/src/lib/lessons.ts
+++ b/src/lib/lessons.ts
@@ -49,6 +49,10 @@ export function formatDuration(duration: string | undefined | null): string {
   return [match[1] ? `${match[1]}h` : '', match[2] ? `${match[2]}m` : ''].filter(Boolean).join(' ');
 }
 
+// Curated-vs-created lives in lib/provenance.ts (dependency-free so client
+// components can import it). Re-exported here for server-side convenience.
+export { CREATOR_ORG, isCreatedByUs } from './provenance';
+
 export async function getLessons(): Promise<Lesson[]> {
   const entries = await getCollection('lessons');
   return entries.map((entry) => {

--- a/src/lib/provenance.ts
+++ b/src/lib/provenance.ts
@@ -1,0 +1,20 @@
+// Curated (external resource we selected) vs. Created (we authored it).
+// Kept dependency-free so it can be imported by client components — importing
+// from lessons.ts would pull in the server-only `astro:content` module.
+
+// The organization that authors the lessons we create ourselves.
+export const CREATOR_ORG = 'UC OSPO Network';
+
+/**
+ * True if we authored this lesson (vs. curated it from an external source).
+ * Signal: provider is our org, or the source/repo lives in our namespace.
+ */
+export function isCreatedByUs(lesson: {
+  provider?: string | null;
+  repoUrl?: string | null;
+  url?: string | null;
+}): boolean {
+  if ((lesson.provider ?? '').trim() === CREATOR_ORG) return true;
+  const haystack = `${lesson.repoUrl ?? ''} ${lesson.url ?? ''}`.toLowerCase();
+  return haystack.includes('uc-ospo-network') || haystack.includes('ucospo.net');
+}

--- a/src/pages/lessons/[slug].astro
+++ b/src/pages/lessons/[slug].astro
@@ -2,7 +2,7 @@
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import LessonJsonLd from "../../components/LessonJsonLd.astro";
 import Citation from "../../components/Citation.astro";
-import { getLessons, getRelatedLessons, type Lesson, formatDuration } from "../../lib/lessons";
+import { getLessons, getRelatedLessons, type Lesson, formatDuration, isCreatedByUs } from "../../lib/lessons";
 import { lookupProvider } from "../../lib/providers";
 import { normalizeCitation } from "../../lib/citation";
 import { getCollection } from "astro:content";
@@ -142,6 +142,15 @@ const hasPrereqs =
       </nav>
 
       <div class="lesson-badges">
+        {isCreatedByUs(lesson) ? (
+          <span class="lesson-badge lesson-badge--created" title="Created by the UC OSPO Network">
+            Created by us
+          </span>
+        ) : (
+          <span class="lesson-badge lesson-badge--curated" title="An external resource curated by the UC OSPO Network">
+            Curated · external resource
+          </span>
+        )}
         {pathwayName && (
           <span class="lesson-badge lesson-badge--pathway">
             {pathwayName}


### PR DESCRIPTION
Closes #144.

Makes explicit that catalog lessons are **external resources we curated** vs. ones **we created** — on lesson cards and lesson pages — and encodes it machine-readably. This is a direct iteration on the existing Bioschemas `TrainingMaterial` JSON-LD, and the approach follows the IA research + the IMLS site precedent. No schema or content migration: provenance is derived from the existing `provider` field.

## Changes
- **`src/lib/provenance.ts`** (new): `isCreatedByUs()` — true when `provider` is our org or the source/repo is in our namespace — plus `CREATOR_ORG`. Kept dependency-free so the `LessonCard` client island can import it (importing from `lessons.ts` would pull in the server-only `astro:content`). Re-exported from `lessons.ts` for server-side use.
- **Lesson page** (`[slug].astro`): a "Curated · external resource" / "Created by us" badge.
- **Lesson card** (`LessonCard.jsx`): a Curated/Created tag in the meta strip.
- **JSON-LD** (`LessonJsonLd.astro`): `sdPublisher` = UC OSPO Network (we publish the structured data); for curated items `sameAs` = canonical source + `publisher` = source provider; for created items `publisher` = us; plus `EducationalAudience.educationalRole` (`student` for guides, `student`+`teacher` for taught formats).

## Data reality
Currently 1 lesson is created-by-us (`provider: "UC OSPO Network"`); the rest are curated. The signal also matches repos/URLs in our namespace, so newly authored lessons flip automatically.

## Verification
- `astro build` passes (80 pages)
- Detail pages render the correct badge; JSON-LD emits `sdPublisher` / `sameAs` / `educationalRole` and the right `publisher`
- ESLint clean on `LessonCard.jsx`

Independent of #149/#150/#151; minor overlap with #149 on `LessonCard.jsx` (different lines), resolvable at merge.