### PR TITLE
data: standardize lesson author metadata (#94)

### DIFF
--- a/keystatic.config.ts
+++ b/keystatic.config.ts
@@ -130,7 +130,13 @@ export default config({
           label: 'Lesson URL',
           validation: { isRequired: true },
         }),
-        author: fields.text({ label: 'Author' }),
+        author: fields.text({
+          label: 'Author',
+          description:
+            'Use one of two forms: an organization or team name (e.g. "CodeRefinery Team"), ' +
+            'or a person as "Full Name <email@example.com>". For multiple people, separate with commas. ' +
+            'Do not append an email to an organization name.',
+        }),
         provider: fields.text({
           label: 'Provider (organization)',
           description: 'Organization that produced this lesson (e.g. UC Davis DataLab, CodeRefinery). Follows Bioschemas TrainingMaterial provider field.',

--- a/src/content/lessons/continuous-integration-and-delivery-with-github-actions.json
+++ b/src/content/lessons/continuous-integration-and-delivery-with-github-actions.json
@@ -8,7 +8,7 @@
     "subTopic": "Testing",
     "educationalLevel": "Intermediate",
     "learningResourceType": "workshop",
-    "author": "Intersect Team, intersect@training.org",
+    "author": "INTERSECT Team",
     "license": "https://creativecommons.org/licenses/by/4.0/",
     "inLanguage": [
         "en"

--- a/src/content/lessons/effective-code-review.json
+++ b/src/content/lessons/effective-code-review.json
@@ -4,7 +4,7 @@
     "keepStatus": "keep",
     "description": "This lesson teaches best practices for conducting and participating in code reviews, emphasizing clear communication and collaborative problem solving.",
     "url": "https://intersect-training.org/Code-Review/",
-    "author": "Intersect Team, intersect@training.org",
+    "author": "INTERSECT Team",
     "license": "https://creativecommons.org/licenses/by/4.0/",
     "educationalLevel": "Intermediate",
     "learningResourceType": "workshop",

--- a/src/content/lessons/introduction-to-docker-for-research-note-this-is-now-called-introduction-to-docker-and-podman.json
+++ b/src/content/lessons/introduction-to-docker-for-research-note-this-is-now-called-introduction-to-docker-and-podman.json
@@ -8,7 +8,7 @@
     "subTopic": "Reproducible Research",
     "educationalLevel": "Beginner",
     "learningResourceType": "workshop",
-    "author": "HSF Training Center",
+    "author": "HSF Training Team",
     "license": "https://creativecommons.org/licenses/by/4.0/",
     "inLanguage": [
         "en"

--- a/src/content/lessons/issue-tracking-with-github.json
+++ b/src/content/lessons/issue-tracking-with-github.json
@@ -8,7 +8,7 @@
     "subTopic": "Version Control Basics",
     "educationalLevel": "Intermediate",
     "learningResourceType": "workshop",
-    "author": "Intersect Team, intersect@training.org",
+    "author": "INTERSECT Team",
     "license": "https://creativecommons.org/licenses/by/4.0/",
     "inLanguage": [
         "en"

--- a/src/content/lessons/making-good-pull-requests.json
+++ b/src/content/lessons/making-good-pull-requests.json
@@ -8,7 +8,7 @@
     "subTopic": "Version Control Basics",
     "educationalLevel": "Beginner",
     "learningResourceType": "workshop",
-    "author": "Intersect Team, intersect@training.org",
+    "author": "INTERSECT Team",
     "license": "https://creativecommons.org/licenses/by/4.0/",
     "inLanguage": [
         "en"

--- a/src/content/lessons/python-packaging-for-beginners.json
+++ b/src/content/lessons/python-packaging-for-beginners.json
@@ -8,7 +8,7 @@
     "subTopic": "Packaging",
     "educationalLevel": "Intermediate",
     "learningResourceType": "workshop",
-    "author": "Intersect Team, intersect@training.org",
+    "author": "INTERSECT Team",
     "license": "https://creativecommons.org/licenses/by/4.0/",
     "inLanguage": [
         "en"

--- a/src/content/lessons/unit-testing-and-tdd-in-python.json
+++ b/src/content/lessons/unit-testing-and-tdd-in-python.json
@@ -8,7 +8,7 @@
     "subTopic": "Testing",
     "educationalLevel": "Intermediate",
     "learningResourceType": "course",
-    "author": "Intersect Team, intersect@training.org",
+    "author": "INTERSECT Team",
     "license": "https://creativecommons.org/licenses/by/4.0/",
     "inLanguage": [
         "en"

--- a/src/content/lessons/writing-documentation-for-software-projects.json
+++ b/src/content/lessons/writing-documentation-for-software-projects.json
@@ -8,7 +8,7 @@
     "subTopic": "Open Source Literacy",
     "educationalLevel": "Intermediate",
     "learningResourceType": "workshop",
-    "author": "Intersect Team, intersect@training.org",
+    "author": "INTERSECT Team",
     "license": "https://creativecommons.org/licenses/by/4.0/",
     "inLanguage": [
         "en"


### PR DESCRIPTION
Closes #94.

Normalizes the `author` field to the two consistent forms from the issue (organization/team name, or `Full Name <email>` for people).

## Changes
- **`Intersect Team, intersect@training.org` → `INTERSECT Team`** (7 lessons): drops the email embedded in an org-name field and matches the provider casing ("INTERSECT").
- **`HSF Training Center` → `HSF Training Team`**: unifies the two HSF variants.
- **Keystatic**: adds a description on the Author field documenting the convention (org/team name, or `Full Name <email>`; comma-separate multiple people; do not append an email to an org name) so future entries stay consistent.

The remaining authors were already valid org names; the one multi-person entry (Bernholdt et al.) is kept as comma-separated names. Kept the field as a string with a documented convention rather than migrating to an array, to avoid a schema change across consumers.

## Verification
- `npm run validate:lessons` passes (66 lessons, 0 errors)
- `astro build` passes (80 pages)
- No residual email-in-author values; HSF unified