### PR TITLE
feat(provenance): scope curated/created signposting by surface (#144)

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -710,6 +710,19 @@ summary:focus-visible {
   margin-right: auto;
 }
 
+.page-intro__note {
+  margin: 0.75rem 0 0;
+  max-width: 44rem;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  opacity: 0.85;
+}
+
+.page-intro__note strong {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
 .page-intro__actions {
   display: flex;
   flex-wrap: wrap;

--- a/src/components/LessonCard.jsx
+++ b/src/components/LessonCard.jsx
@@ -104,12 +104,16 @@ export default function LessonCard({ lesson, lessonIndex = {}, headingLevel = 3,
         <p className="lesson-card__meta-type">
           {TypeIcon && <TypeIcon className="lesson-card__meta-type-icon" aria-hidden="true" />}
           {topMeta}
-          <span
-            className={`lesson-card__provenance lesson-card__provenance--${createdByUs ? "created" : "curated"}`}
-            title={createdByUs ? "Created by the UC OSPO Network" : "An external resource curated by the UC OSPO Network"}
-          >
-            {createdByUs ? "Created" : "Curated"}
-          </span>
+          {/* Curation is the site-wide norm (stated on the lessons index), so we
+              only flag the exception here: lessons the OSPO Network authored. */}
+          {createdByUs && (
+            <span
+              className="lesson-card__provenance lesson-card__provenance--created"
+              title="Created by the UC OSPO Network"
+            >
+              Created
+            </span>
+          )}
         </p>
         {roleTags.length > 0 && (
           <p className="lesson-card__meta-role">{roleTags.join(", ")}</p>

--- a/src/components/lessons/lessons.css
+++ b/src/components/lessons/lessons.css
@@ -272,12 +272,6 @@
   border-color: rgba(0, 85, 129, 0.3);
 }
 
-.lesson-card__provenance--curated {
-  background: var(--bg-surface-strong);
-  color: var(--text-secondary);
-  border-color: var(--border-light);
-}
-
 .lesson-card__meta-type-icon {
   width: 0.85rem;
   height: 0.85rem;

--- a/src/pages/lessons.astro
+++ b/src/pages/lessons.astro
@@ -30,6 +30,10 @@ const pathwayNames = Object.fromEntries(pathways.map((p) => [p.id, p.data.name])
         Browse the full library of curated open source learning materials, then filter by role,
         pathway, skill level, or topic.
       </p>
+      <p class="page-intro__note">
+        Except where marked <strong>Created</strong>, these are external resources curated by the
+        UC OSPO Network: selected and organized by us, but authored by others.
+      </p>
     </div>
   </section>
 


### PR DESCRIPTION
Refines the curated/created signposting from #144 so the signal lands where it carries meaning instead of repeating a constant on every card.

## Rationale
Curation is the site-wide norm: 33 of 34 lessons are external resources we curated. A per-card "Curated" badge is therefore a constant, not information. Issue #144 (by @LauraLangdon) asked for signposting on **the landing page and every lesson** so visitors understand these are external resources the OSPO did not author. This keeps that attribution promise where it actually matters and reclaims the redundant card space.

## Changes by surface
- **Lessons index** (`lessons.astro`): adds one global note — "Except where marked Created, these are external resources curated by the UC OSPO Network: selected and organized by us, but authored by others." Satisfies the landing-page ask.
- **Lesson detail page** (`[slug].astro`): unchanged. Keeps the full "Curated · external resource" / "Created by us" badge where attribution matters most for a deep-linked or searched visitor. Satisfies the per-lesson ask.
- **Lesson cards / grid** (`LessonCard.jsx`): drops the repetitive "Curated"; shows the "Created" marker only for OSPO-authored lessons (the exception). Removes now-dead `--curated` card styles.

## Verification
- `astro build` succeeds (79 pages)