### PR TITLE
Lessons: reconcile Pathway facet to journey stages

### DIFF
--- a/scripts/migrate-pathways.mjs
+++ b/scripts/migrate-pathways.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+// One-off pathway reconciliation (HANDOFF #1).
+//
+// Pathways become a pure journey-stage facet now that subject lives in the
+// Topic facet. Four stages survive: getting-started (Start here),
+// contributing (Contribute — incl. technical craft), maintaining (Maintain),
+// strategic (Lead & sustain). The `building-communities` and `licensing`
+// pathways retire (their lessons are covered by the Topic facet).
+//
+// Each lesson gets exactly one stage. Mapping is explicit by slug — this is a
+// curated migration, not a rule-based normalizer.
+//
+// Usage:
+//   node scripts/migrate-pathways.mjs            # dry run (default)
+//   node scripts/migrate-pathways.mjs --write    # persist changes
+
+import { readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const DIR = "src/content/lessons";
+const WRITE = process.argv.includes("--write");
+
+// slug -> target pathway stage
+const TARGET = {
+  // Start here
+  "what-is-open-source": "getting-started",
+  "introduction-to-git": "getting-started",
+  "making-good-pull-requests": "getting-started",
+  "your-first-web-contribution": "getting-started",
+  "how-to-contribute-to-open-source": "getting-started",
+  "social-coding-and-open-source-collaboration": "getting-started",
+  "understanding-software-licensing": "getting-started",
+  "starting-an-open-source-project": "getting-started", // was maintaining
+
+  // Contribute (incl. technical craft, moved out of maintaining)
+  "collaboration-in-open-research-projects": "contributing",
+  "collaborative-git-for-teams": "contributing",
+  "issue-tracking-with-github": "contributing",
+  "writing-documentation-for-software-projects": "contributing",
+  "building-better-research-software": "contributing",
+  "cicd-for-research-software-with-gitlab-ci": "contributing",
+  "continuous-integration-and-delivery-with-github-actions": "contributing",
+  "good-enough-practices-in-scientific-computing": "contributing",
+  "intermediate-research-software-development-skills-python-lesson-material": "contributing",
+  "introduction-to-docker-for-research-note-this-is-now-called-introduction-to-docker-and-podman": "contributing",
+  "modular-programming-with-python": "contributing",
+  "python-package-development-best-practices": "contributing",
+  "python-packaging": "contributing",
+  "python-packaging-for-beginners": "contributing",
+  "r-packaging": "contributing",
+  "reproducible-computational-environments-using-containers": "contributing",
+  "reproducible-research": "contributing",
+  "research-software-engineering-with-python-course": "contributing",
+  "research-software-citable-discoverable": "contributing",
+  "testing-and-test-driven-development": "contributing",
+  "unit-testing-and-tdd-in-python": "contributing",
+
+  // Maintain
+  "best-practices-for-maintainers": "maintaining",
+  "maintaining-balance-for-open-source-maintainers": "maintaining",
+  "effective-code-review": "maintaining",
+  "security-best-practices-for-your-project": "maintaining",
+  "accessibility-best-practices-for-your-project": "maintaining",
+
+  // Lead & sustain
+  "getting-paid-for-open-source-work": "strategic",
+  "metrics-model-oss-project-viability-strategy": "strategic",
+  "metrics-model-starter-project-health": "strategic",
+  "metrics": "strategic", // was maintaining
+  "finding-users-for-your-project": "strategic", // was maintaining
+  "building-community": "strategic", // was building-communities
+  "leadership-and-governance": "strategic", // was building-communities
+  "code-of-conduct": "strategic", // was building-communities
+  "the-legal-side-of-open-source": "strategic", // was licensing
+};
+
+const isKept = (d) => (d.keepStatus ?? "keepCandidate") !== "drop" && (d.url ?? "").trim() !== "";
+
+const changes = [];
+const unmapped = [];
+const dist = {};
+
+for (const file of readdirSync(DIR)) {
+  if (!file.endsWith(".json")) continue;
+  const path = join(DIR, file);
+  const data = JSON.parse(readFileSync(path, "utf8"));
+  if (!isKept(data)) continue;
+
+  const slug = data.slug;
+  const target = TARGET[slug];
+  if (!target) {
+    unmapped.push(slug);
+    continue;
+  }
+
+  dist[target] = (dist[target] ?? 0) + 1;
+  const before = (data.pathways ?? []).join("+");
+  if (before === target) continue;
+
+  changes.push({ slug, before: before || "—", after: target });
+  if (WRITE) {
+    data.pathways = [target];
+    writeFileSync(path, JSON.stringify(data, null, 2) + "\n");
+  }
+}
+
+console.log(`\n${WRITE ? "WROTE" : "DRY RUN —"} ${changes.length} pathway change(s):\n`);
+for (const c of changes) {
+  console.log(`  ${c.slug}\n      ${c.before}  ->  ${c.after}`);
+}
+console.log("\nResulting distribution:");
+for (const [k, v] of Object.entries(dist).sort()) console.log(`  ${k.padEnd(18)} ${v}`);
+if (unmapped.length) {
+  console.log(`\n⚠ ${unmapped.length} kept lesson(s) NOT in the map (left unchanged):`);
+  unmapped.forEach((s) => console.log(`  ${s}`));
+}
+if (!WRITE) console.log("\nRe-run with --write to persist.");

--- a/src/content/lessons/building-better-research-software.json
+++ b/src/content/lessons/building-better-research-software.json
@@ -51,7 +51,7 @@
     "Maintainer"
   ],
   "pathways": [
-    "maintaining"
+    "contributing"
   ],
   "prerequisites": [
     {

--- a/src/content/lessons/building-community.json
+++ b/src/content/lessons/building-community.json
@@ -74,7 +74,7 @@
     "Maintainer"
   ],
   "pathways": [
-    "building-communities"
+    "strategic"
   ],
   "prerequisites": [
     {

--- a/src/content/lessons/cicd-for-research-software-with-gitlab-ci.json
+++ b/src/content/lessons/cicd-for-research-software-with-gitlab-ci.json
@@ -50,7 +50,7 @@
     "Maintainer"
   ],
   "pathways": [
-    "maintaining"
+    "contributing"
   ],
   "prerequisites": [
     {

--- a/src/content/lessons/code-of-conduct.json
+++ b/src/content/lessons/code-of-conduct.json
@@ -76,7 +76,7 @@
     "Maintainer"
   ],
   "pathways": [
-    "building-communities"
+    "strategic"
   ],
   "prerequisites": [
     {

--- a/src/content/lessons/continuous-integration-and-delivery-with-github-actions.json
+++ b/src/content/lessons/continuous-integration-and-delivery-with-github-actions.json
@@ -50,7 +50,7 @@
     "Maintainer"
   ],
   "pathways": [
-    "maintaining"
+    "contributing"
   ],
   "prerequisites": [
     {

--- a/src/content/lessons/finding-users-for-your-project.json
+++ b/src/content/lessons/finding-users-for-your-project.json
@@ -73,7 +73,7 @@
     "Community Manager"
   ],
   "pathways": [
-    "maintaining"
+    "strategic"
   ],
   "prerequisites": [
     {

--- a/src/content/lessons/good-enough-practices-in-scientific-computing.json
+++ b/src/content/lessons/good-enough-practices-in-scientific-computing.json
@@ -52,7 +52,7 @@
     "Maintainer"
   ],
   "pathways": [
-    "maintaining"
+    "contributing"
   ],
   "prerequisites": [],
   "provider": "The Carpentries Lab",

--- a/src/content/lessons/intermediate-research-software-development-skills-python-lesson-material.json
+++ b/src/content/lessons/intermediate-research-software-development-skills-python-lesson-material.json
@@ -50,7 +50,7 @@
     "Maintainer"
   ],
   "pathways": [
-    "maintaining"
+    "contributing"
   ],
   "prerequisites": [
     {

--- a/src/content/lessons/introduction-to-docker-for-research-note-this-is-now-called-introduction-to-docker-and-podman.json
+++ b/src/content/lessons/introduction-to-docker-for-research-note-this-is-now-called-introduction-to-docker-and-podman.json
@@ -51,7 +51,7 @@
     "Maintainer"
   ],
   "pathways": [
-    "maintaining"
+    "contributing"
   ],
   "prerequisites": [],
   "provider": "HSF Training",

--- a/src/content/lessons/leadership-and-governance.json
+++ b/src/content/lessons/leadership-and-governance.json
@@ -74,7 +74,7 @@
     "Contributor"
   ],
   "pathways": [
-    "building-communities"
+    "strategic"
   ],
   "prerequisites": [
     {

--- a/src/content/lessons/metrics.json
+++ b/src/content/lessons/metrics.json
@@ -74,7 +74,7 @@
     "Maintainer"
   ],
   "pathways": [
-    "maintaining"
+    "strategic"
   ],
   "prerequisites": [
     {

--- a/src/content/lessons/modular-programming-with-python.json
+++ b/src/content/lessons/modular-programming-with-python.json
@@ -50,7 +50,7 @@
     "Maintainer"
   ],
   "pathways": [
-    "maintaining"
+    "contributing"
   ],
   "prerequisites": [
     {

--- a/src/content/lessons/python-package-development-best-practices.json
+++ b/src/content/lessons/python-package-development-best-practices.json
@@ -51,7 +51,7 @@
     "Maintainer"
   ],
   "pathways": [
-    "maintaining"
+    "contributing"
   ],
   "prerequisites": [
     {

--- a/src/content/lessons/python-packaging-for-beginners.json
+++ b/src/content/lessons/python-packaging-for-beginners.json
@@ -50,7 +50,7 @@
     "Maintainer"
   ],
   "pathways": [
-    "maintaining"
+    "contributing"
   ],
   "prerequisites": [
     {

--- a/src/content/lessons/python-packaging.json
+++ b/src/content/lessons/python-packaging.json
@@ -50,7 +50,7 @@
     "Maintainer"
   ],
   "pathways": [
-    "maintaining"
+    "contributing"
   ],
   "prerequisites": [
     {

--- a/src/content/lessons/r-packaging.json
+++ b/src/content/lessons/r-packaging.json
@@ -50,7 +50,7 @@
     "Maintainer"
   ],
   "pathways": [
-    "maintaining"
+    "contributing"
   ],
   "prerequisites": [
     {

--- a/src/content/lessons/reproducible-computational-environments-using-containers.json
+++ b/src/content/lessons/reproducible-computational-environments-using-containers.json
@@ -50,7 +50,7 @@
     "Maintainer"
   ],
   "pathways": [
-    "maintaining"
+    "contributing"
   ],
   "prerequisites": [
     {

--- a/src/content/lessons/reproducible-research.json
+++ b/src/content/lessons/reproducible-research.json
@@ -50,7 +50,7 @@
     "Maintainer"
   ],
   "pathways": [
-    "maintaining"
+    "contributing"
   ],
   "prerequisites": [
     {

--- a/src/content/lessons/research-software-citable-discoverable.json
+++ b/src/content/lessons/research-software-citable-discoverable.json
@@ -53,7 +53,7 @@
     "Maintainer"
   ],
   "pathways": [
-    "maintaining"
+    "contributing"
   ],
   "prerequisites": [
     {

--- a/src/content/lessons/research-software-engineering-with-python-course.json
+++ b/src/content/lessons/research-software-engineering-with-python-course.json
@@ -50,7 +50,7 @@
     "Maintainer"
   ],
   "pathways": [
-    "maintaining"
+    "contributing"
   ],
   "prerequisites": [
     {

--- a/src/content/lessons/starting-an-open-source-project.json
+++ b/src/content/lessons/starting-an-open-source-project.json
@@ -74,7 +74,7 @@
     "Maintainer"
   ],
   "pathways": [
-    "maintaining"
+    "getting-started"
   ],
   "prerequisites": [
     {

--- a/src/content/lessons/testing-and-test-driven-development.json
+++ b/src/content/lessons/testing-and-test-driven-development.json
@@ -50,7 +50,7 @@
     "Maintainer"
   ],
   "pathways": [
-    "maintaining"
+    "contributing"
   ],
   "prerequisites": [
     {

--- a/src/content/lessons/the-legal-side-of-open-source.json
+++ b/src/content/lessons/the-legal-side-of-open-source.json
@@ -76,7 +76,7 @@
     "Project Lead"
   ],
   "pathways": [
-    "licensing"
+    "strategic"
   ],
   "prerequisites": [
     {

--- a/src/content/lessons/unit-testing-and-tdd-in-python.json
+++ b/src/content/lessons/unit-testing-and-tdd-in-python.json
@@ -50,7 +50,7 @@
     "Maintainer"
   ],
   "pathways": [
-    "maintaining"
+    "contributing"
   ],
   "prerequisites": [
     {

--- a/src/content/pathways/building-communities.json
+++ b/src/content/pathways/building-communities.json
@@ -1,6 +1,0 @@
-{
-    "name": "Building Inclusive Communities",
-    "description": "For those organizing people, not just code.",
-    "icon": "🌱",
-    "order": 4
-}

--- a/src/content/pathways/licensing.json
+++ b/src/content/pathways/licensing.json
@@ -1,6 +1,0 @@
-{
-    "name": "Understanding Licensing & Compliance",
-    "description": "For anyone navigating open source legalities, especially in a UC context.",
-    "icon": "⚖️",
-    "order": 5
-}


### PR DESCRIPTION
Follow-on to #156. The **Pathway** facet had drifted into a dumping ground: `maintaining` was tagged on **25 of 43** lessons — mostly technical-craft RSE material (packaging, testing, CI/CD, reproducibility, Docker) that had nowhere else to live. Now that subject lives in the **Topic** facet, pathways become a pure **journey-stage** axis.

## Changes
- **24 lessons retagged** to one of four stages. Distribution goes from `25/7/4/3/3/1` → **`contributing 21 · getting-started 8 · strategic 9 · maintaining 5`**.
  - **Start here** (`getting-started`, 8) — newcomers to OSS
  - **Contribute** (`contributing`, 21) — writing code/docs **and the technical craft to do it well**
  - **Maintain** (`maintaining`, 5) — running & sustaining a project
  - **Lead & sustain** (`strategic`, 9) — governance, metrics, growth, career
- **Retired `building-communities` and `licensing` as pathways** — both are covered by the Topic facet now. Their lessons move to a journey stage; removing the collection files drops the two empty landing pages (page count 80→78).
- Migration is an explicit per-slug map in `scripts/migrate-pathways.mjs` (dry-run default, `--write` to persist).

## Verification
- `npm run build` green; `/pathways` shows exactly 4 cards with correct counts (8 / 21 / 5 / 9), no empty cards.
- Pathway facet on `/lessons` now offers 4 meaningful options instead of one that matched 58% of the catalog.

## Follow-up (not in this PR)
- Pathway **descriptions** are now slightly stale — e.g. "Contributing to a Project" doesn't mention the technical-craft lessons folded in. Worth a copy refresh.
- Dead `building-communities`/`licensing` members remain in the homepage `CategoryIconName` union (harmless; left to avoid scope creep).