### PR TITLE
Lessons: topic DefinedTermSet + per-topic landing pages

### DIFF
--- a/src/components/LessonJsonLd.astro
+++ b/src/components/LessonJsonLd.astro
@@ -2,6 +2,7 @@
 import type { Lesson } from "../lib/lessons";
 import { isCreatedByUs, CREATOR_ORG } from "../lib/provenance";
 import { getCollection } from "astro:content";
+import { topicByName, termId, termSetId } from "../data/topics";
 
 interface Props {
   lesson: Lesson;
@@ -33,6 +34,21 @@ if (nonEmpty(canonicalUrl)) data.url = canonicalUrl;
 if (nonEmpty(lesson.educationalLevel)) data.educationalLevel = lesson.educationalLevel;
 if (nonEmpty(lesson.learningResourceType)) data.learningResourceType = lesson.learningResourceType;
 if (nonEmpty(lesson.keywords)) data.keywords = lesson.keywords;
+
+// Controlled topics go in `about` as DefinedTerms referencing the published
+// term set; raw free-text stays in `keywords`. Each term @id resolves to its
+// landing page, where the external crosswalk (skos:closeMatch) is published.
+const aboutTerms = lesson.topics
+  .map((name) => topicByName(name))
+  .filter((t): t is NonNullable<typeof t> => t !== undefined)
+  .map((t) => ({
+    "@type": "DefinedTerm",
+    "@id": termId(Astro.site, t.termCode),
+    name: t.name,
+    termCode: t.termCode,
+    inDefinedTermSet: termSetId(Astro.site),
+  }));
+if (aboutTerms.length > 0) data.about = aboutTerms;
 if (nonEmpty(lesson.timeRequired)) data.timeRequired = lesson.timeRequired;
 if (nonEmpty(lesson.inLanguage)) data.inLanguage = lesson.inLanguage;
 if (nonEmpty(lesson.license)) data.license = lesson.license;

--- a/src/data/topics.ts
+++ b/src/data/topics.ts
@@ -1,0 +1,137 @@
+// Controlled topic vocabulary, published as a schema.org DefinedTermSet.
+//
+// Each of the 13 topics carries a stable local URI (via `termCode`) and an
+// external crosswalk anchor (the closest authoritative scheme), so the topics
+// are machine-readable and formally grounded, not just local strings. Anchors
+// follow the topic-taxonomy validation report (ACM CCS / CHAOSS / FAIR4RS /
+// OpenSSF / WCAG / RSE competencies / The Turing Way).
+//
+// The term set lives at /lessons/topic; each term at /lessons/topic/<termCode>,
+// which doubles as the human browse page (#5) and the DefinedTerm @id (#2).
+
+export interface TopicCrosswalk {
+  /** Human label for the external authority. */
+  label: string;
+  /** Canonical URI of the external scheme (SKOS closeMatch target). */
+  uri: string;
+}
+
+export interface TopicTerm {
+  /** Canonical name; must match the `topics` enum in content/config.ts. */
+  name: string;
+  /** Stable slug used in the term URI and as schema.org termCode. */
+  termCode: string;
+  /** Short description for the term/landing page. */
+  description: string;
+  /** Closest external authority for formal crosswalk semantics. */
+  crosswalk: TopicCrosswalk;
+}
+
+/** Path of the DefinedTermSet (and the browse-by-topic index). */
+export const TERM_SET_PATH = "/lessons/topic";
+
+export const TOPIC_TERMS: TopicTerm[] = [
+  {
+    name: "Version Control & Collaborative Development",
+    termCode: "version-control-collaborative-development",
+    description:
+      "Tracking changes with Git and collaborating through branches, pull requests, and shared repositories.",
+    crosswalk: { label: "RSE Competencies (F1000Research)", uri: "https://f1000research.com/articles/13-1429" },
+  },
+  {
+    name: "Documentation & Technical Writing",
+    termCode: "documentation-technical-writing",
+    description: "Writing READMEs, tutorials, API references, and other documentation that helps people use and contribute to software.",
+    crosswalk: { label: "The Turing Way", uri: "https://book.the-turing-way.org/" },
+  },
+  {
+    name: "Licensing, Copyright & Reuse",
+    termCode: "licensing-copyright-reuse",
+    description: "Choosing and applying open source licenses, and understanding copyright, attribution, and the terms of reuse.",
+    crosswalk: { label: "Open Source Definition (OSI)", uri: "https://opensource.org/osd" },
+  },
+  {
+    name: "Community, Governance & Conduct",
+    termCode: "community-governance-conduct",
+    description: "Building healthy communities: codes of conduct, governance models, inclusive communication, and contributor relations.",
+    crosswalk: { label: "The Turing Way", uri: "https://book.the-turing-way.org/" },
+  },
+  {
+    name: "Project Planning, Maintenance & Sustainability",
+    termCode: "project-planning-maintenance-sustainability",
+    description: "Planning, maintaining, and sustaining a project over time: workload, roadmaps, and keeping contributors engaged.",
+    crosswalk: {
+      label: "CHAOSS: Contributor Sustainability",
+      uri: "https://chaoss.community/practitioner-guide-contributor-sustainability/",
+    },
+  },
+  {
+    name: "Quality, Testing, Review & Automation",
+    termCode: "quality-testing-review-automation",
+    description: "Testing, code review, continuous integration, and automation that keep software correct and maintainable.",
+    crosswalk: { label: "RSE Competencies (F1000Research)", uri: "https://f1000research.com/articles/13-1429" },
+  },
+  {
+    name: "Software Design & Engineering Practices",
+    termCode: "software-design-engineering-practices",
+    description: "Designing and structuring software well: modularity, architecture, and general software engineering practice.",
+    crosswalk: { label: "RSE Competencies (F1000Research)", uri: "https://f1000research.com/articles/13-1429" },
+  },
+  {
+    name: "Packaging, Release & Distribution",
+    termCode: "packaging-release-distribution",
+    description: "Packaging software for Python, R, and other ecosystems, and releasing and distributing it to users.",
+    crosswalk: { label: "RSE Competencies (F1000Research)", uri: "https://f1000research.com/articles/13-1429" },
+  },
+  {
+    name: "Reproducibility, Environments & Workflows",
+    termCode: "reproducibility-environments-workflows",
+    description: "Reproducible computational environments and workflows using containers, environment management, and pipelines.",
+    crosswalk: { label: "The Turing Way", uri: "https://book.the-turing-way.org/" },
+  },
+  {
+    name: "Open Science, FAIR & Research Software Metadata",
+    termCode: "open-science-fair-research-software-metadata",
+    description: "Making research software findable, accessible, interoperable, and reusable: citation, metadata, and discoverability.",
+    crosswalk: { label: "FAIR4RS Principles (RDA)", uri: "https://doi.org/10.15497/RDA00068" },
+  },
+  {
+    name: "Project Health, Metrics & Assessment",
+    termCode: "project-health-metrics-assessment",
+    description: "Measuring and assessing the health, viability, and risk of open source projects.",
+    crosswalk: { label: "CHAOSS: Assessing Viability", uri: "https://chaoss.community/practitioner-guide-viability/" },
+  },
+  {
+    name: "Security & Supply Chain",
+    termCode: "security-supply-chain",
+    description: "Securing source code, dependencies, and the software supply chain.",
+    crosswalk: { label: "OpenSSF SCM Best Practices", uri: "https://best.openssf.org/SCM-BestPractices/" },
+  },
+  {
+    name: "Accessibility & Inclusive Design",
+    termCode: "accessibility-inclusive-design",
+    description: "Making software and its documentation usable by everyone, including people with disabilities.",
+    crosswalk: { label: "WCAG (W3C)", uri: "https://www.w3.org/WAI/standards-guidelines/wcag/" },
+  },
+];
+
+const BY_NAME = new Map(TOPIC_TERMS.map((t) => [t.name, t]));
+const BY_CODE = new Map(TOPIC_TERMS.map((t) => [t.termCode, t]));
+
+export function topicByName(name: string): TopicTerm | undefined {
+  return BY_NAME.get(name);
+}
+
+export function topicByCode(code: string): TopicTerm | undefined {
+  return BY_CODE.get(code);
+}
+
+/** Absolute @id for a term, e.g. https://ucospo.net/lessons/topic/<code>. */
+export function termId(site: URL | undefined, termCode: string): string {
+  return new URL(`${TERM_SET_PATH}/${termCode}`, site ?? "https://ucospo.net").href;
+}
+
+/** Absolute @id for the DefinedTermSet itself. */
+export function termSetId(site: URL | undefined): string {
+  return new URL(TERM_SET_PATH, site ?? "https://ucospo.net").href;
+}

--- a/src/pages/lessons.astro
+++ b/src/pages/lessons.astro
@@ -16,12 +16,33 @@ const pagefindPath = `${import.meta.env.BASE_URL}pagefind/`;
 // Communities" rather than the raw "building-communities" slug.
 const pathways = await getCollection("pathways");
 const pathwayNames = Object.fromEntries(pathways.map((p) => [p.id, p.data.name]));
+
+const base = import.meta.env.BASE_URL;
+const canonicalUrl = new URL("/lessons", Astro.site ?? "https://ucospo.net").href;
 ---
 
 <BaseLayout
   title="All Lessons"
   description="Browse the full library of curated open source education lessons from the UC OSPO Network."
 >
+  <Fragment slot="head">
+    <link rel="canonical" href={canonicalUrl} />
+    {/* Filtered states (?topic=…&role=…) are crawl noise; the topic landing
+        pages are the indexable entry points. Base /lessons stays indexable. */}
+    <script is:inline>
+      (function () {
+        var p = new URLSearchParams(location.search);
+        var keys = ["q", "role", "level", "pathway", "domain", "type", "audience", "topic"];
+        if (keys.some(function (k) { return p.has(k); })) {
+          var m = document.createElement("meta");
+          m.name = "robots";
+          m.content = "noindex,follow";
+          document.head.appendChild(m);
+        }
+      })();
+    </script>
+  </Fragment>
+
   <section class="page-intro">
     <div class="content-container">
       <p class="page-intro__eyebrow">Education</p>
@@ -33,6 +54,9 @@ const pathwayNames = Object.fromEntries(pathways.map((p) => [p.id, p.data.name])
       <p class="page-intro__note">
         Except where marked <strong>Created</strong>, these are external resources curated by the
         UC OSPO Network: selected and organized by us, but authored by others.
+      </p>
+      <p class="page-intro__note">
+        Prefer to browse by subject? See <a href={`${base}lessons/topic`}>all lesson topics</a>.
       </p>
     </div>
   </section>

--- a/src/pages/lessons/topic/[slug].astro
+++ b/src/pages/lessons/topic/[slug].astro
@@ -1,0 +1,102 @@
+---
+import BaseLayout from "../../../layouts/BaseLayout.astro";
+import LessonCard from "../../../components/LessonCard.jsx";
+import { getActiveLessons, type Lesson } from "../../../lib/lessons";
+import { TOPIC_TERMS, topicByCode, termId, termSetId, TERM_SET_PATH, type TopicTerm } from "../../../data/topics";
+import githubHealthRaw from "../../../data/github-health.json";
+import type { HealthSnapshot } from "../../../lib/githubHealth";
+import "../../../components/lessons/lessons.css";
+
+interface Props {
+  term: TopicTerm;
+  lessons: Lesson[];
+}
+
+export async function getStaticPaths() {
+  const lessons = await getActiveLessons();
+  return TOPIC_TERMS.map((term) => ({
+    params: { slug: term.termCode },
+    props: {
+      term,
+      lessons: lessons.filter((l) => l.topics.includes(term.name)),
+    } satisfies Props,
+  }));
+}
+
+const { term, lessons } = Astro.props as Props;
+const healthData = githubHealthRaw as unknown as HealthSnapshot;
+
+const lessonIndex = Object.fromEntries(
+  lessons.filter((l) => l.slug && l.url).map((l) => [l.slug, { name: l.name || l.slug, url: l.url }]),
+);
+
+const base = import.meta.env.BASE_URL;
+const canonicalUrl = new URL(`${TERM_SET_PATH}/${term.termCode}`, Astro.site ?? "https://ucospo.net").href;
+
+// DefinedTerm with a SKOS closeMatch to the external authority. Mixing
+// schema.org and SKOS needs a context object; this is the formal crosswalk.
+const termJsonLd = {
+  "@context": { schema: "https://schema.org/", skos: "http://www.w3.org/2004/02/skos/core#" },
+  "@id": termId(Astro.site, term.termCode),
+  "@type": "schema:DefinedTerm",
+  "schema:name": term.name,
+  "schema:termCode": term.termCode,
+  "schema:description": term.description,
+  "schema:inDefinedTermSet": termSetId(Astro.site),
+  "skos:closeMatch": { "@id": term.crosswalk.uri },
+};
+---
+
+<BaseLayout title={term.name} description={term.description}>
+  <Fragment slot="head">
+    <link rel="canonical" href={canonicalUrl} />
+    <script type="application/ld+json" set:html={JSON.stringify(termJsonLd)} />
+  </Fragment>
+
+  <section class="page-intro">
+    <div class="content-container">
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <ol>
+          <li><a href={base}>Home</a></li>
+          <li class="breadcrumbs__separator" aria-hidden="true">/</li>
+          <li><a href={`${base}lessons`}>Lessons</a></li>
+          <li class="breadcrumbs__separator" aria-hidden="true">/</li>
+          <li><a href={`${base}lessons/topic`}>Topics</a></li>
+          <li class="breadcrumbs__separator" aria-hidden="true">/</li>
+          <li aria-current="page">{term.name}</li>
+        </ol>
+      </nav>
+      <p class="page-intro__eyebrow">Topic</p>
+      <h1 class="page-intro__title">{term.name}</h1>
+      <p class="page-intro__summary">{term.description}</p>
+      <p class="page-intro__note">
+        Related standard:{" "}
+        <a href={term.crosswalk.uri} rel="external nofollow noopener" target="_blank">{term.crosswalk.label}</a>
+      </p>
+      <div class="page-intro__actions">
+        <a class="button-secondary" href={`${base}lessons/topic`}>All topics</a>
+        <a class="button-link" href={`${base}lessons?topic=${encodeURIComponent(term.name)}`}>Filter all lessons</a>
+      </div>
+    </div>
+  </section>
+
+  <div class="content-container" style="padding-bottom: 2rem;">
+    {lessons.length === 0 ? (
+      <section class="page-section empty-state">
+        <p>No lessons are tagged with this topic yet.</p>
+      </section>
+    ) : (
+      <div class="lessons-grid">
+        {lessons.map((lesson) => (
+          <LessonCard
+            lesson={lesson}
+            lessonIndex={lessonIndex}
+            health={healthData.lessons[lesson.slug] ?? null}
+            headingLevel={2}
+            client:load
+          />
+        ))}
+      </div>
+    )}
+  </div>
+</BaseLayout>

--- a/src/pages/lessons/topic/index.astro
+++ b/src/pages/lessons/topic/index.astro
@@ -1,0 +1,124 @@
+---
+import BaseLayout from "../../../layouts/BaseLayout.astro";
+import { getActiveLessons } from "../../../lib/lessons";
+import { TOPIC_TERMS, termId, termSetId, TERM_SET_PATH } from "../../../data/topics";
+
+const lessons = await getActiveLessons();
+
+const countByName: Record<string, number> = {};
+for (const lesson of lessons) {
+  for (const topic of lesson.topics) countByName[topic] = (countByName[topic] ?? 0) + 1;
+}
+
+const base = import.meta.env.BASE_URL;
+const canonicalUrl = new URL(TERM_SET_PATH, Astro.site ?? "https://ucospo.net").href;
+
+// The published DefinedTermSet: each term carries its external crosswalk as a
+// SKOS closeMatch so the set is a small, formally grounded RDF layer.
+const termSetJsonLd = {
+  "@context": { schema: "https://schema.org/", skos: "http://www.w3.org/2004/02/skos/core#" },
+  "@id": termSetId(Astro.site),
+  "@type": "schema:DefinedTermSet",
+  "schema:name": "UC OSPO Education: Lesson Topics",
+  "schema:description":
+    "Controlled vocabulary of open source and research software topics used to classify UC OSPO Network lessons.",
+  "schema:hasDefinedTerm": TOPIC_TERMS.map((term) => ({
+    "@id": termId(Astro.site, term.termCode),
+    "@type": "schema:DefinedTerm",
+    "schema:name": term.name,
+    "schema:termCode": term.termCode,
+    "skos:closeMatch": { "@id": term.crosswalk.uri },
+  })),
+};
+
+const sorted = [...TOPIC_TERMS].sort(
+  (a, b) => (countByName[b.name] ?? 0) - (countByName[a.name] ?? 0) || a.name.localeCompare(b.name),
+);
+---
+
+<BaseLayout
+  title="Lesson Topics"
+  description="Browse UC OSPO Network lessons by topic, a controlled vocabulary grounded in external standards."
+>
+  <Fragment slot="head">
+    <link rel="canonical" href={canonicalUrl} />
+    <script type="application/ld+json" set:html={JSON.stringify(termSetJsonLd)} />
+  </Fragment>
+
+  <section class="page-intro">
+    <div class="content-container">
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <ol>
+          <li><a href={base}>Home</a></li>
+          <li class="breadcrumbs__separator" aria-hidden="true">/</li>
+          <li><a href={`${base}lessons`}>Lessons</a></li>
+          <li class="breadcrumbs__separator" aria-hidden="true">/</li>
+          <li aria-current="page">Topics</li>
+        </ol>
+      </nav>
+      <p class="page-intro__eyebrow">Education</p>
+      <h1 class="page-intro__title">Lesson Topics</h1>
+      <p class="page-intro__summary">
+        Browse lessons by subject. Each topic is part of a controlled vocabulary grounded in an
+        external standard (ACM, CHAOSS, FAIR4RS, OpenSSF, WCAG, and others).
+      </p>
+    </div>
+  </section>
+
+  <div class="content-container" style="padding-bottom: 2rem;">
+    <ul class="topic-term-list">
+      {sorted.map((term) => (
+        <li class="topic-term">
+          <a class="topic-term__link" href={`${base}lessons/topic/${term.termCode}`}>
+            <span class="topic-term__name">{term.name}</span>
+            <span class="topic-term__count">{countByName[term.name] ?? 0}</span>
+          </a>
+          <p class="topic-term__desc">{term.description}</p>
+        </li>
+      ))}
+    </ul>
+  </div>
+</BaseLayout>
+
+<style>
+  .topic-term-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(20rem, 1fr));
+    gap: 1.25rem;
+  }
+  .topic-term {
+    border: 1px solid var(--border-light);
+    border-radius: var(--radius-2xl);
+    background: var(--bg-surface);
+    padding: 1.1rem 1.25rem;
+  }
+  .topic-term__link {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.75rem;
+    font-family: var(--font-sans);
+    font-weight: 600;
+    font-size: 1.02rem;
+    color: var(--text-primary);
+    text-decoration: none;
+  }
+  .topic-term__link:hover .topic-term__name {
+    text-decoration: underline;
+  }
+  .topic-term__count {
+    flex: none;
+    font-size: 0.78rem;
+    color: var(--text-secondary);
+    font-variant-numeric: tabular-nums;
+  }
+  .topic-term__desc {
+    margin: 0.5rem 0 0;
+    font-size: 0.85rem;
+    line-height: 1.45;
+    color: var(--text-secondary);
+  }
+</style>


### PR DESCRIPTION
Implements the two remaining taxonomy items from the IA proposal: machine-readable topics (#2) and crawlable facet landing pages (#5). They share one URL space, so they ship together.

## #2 — Machine-readable topic encoding
- New `src/data/topics.ts` is the single source for the 13-term vocabulary: each term has a stable URI (`/lessons/topic/<termCode>`), a schema.org `termCode`, a description, and a **SKOS `closeMatch`** to its external authority (CHAOSS, FAIR4RS/RDA, OpenSSF, WCAG, OSI, The Turing Way, RSE competencies).
- Published as a schema.org **`DefinedTermSet`** at `/lessons/topic`.
- Each lesson's JSON-LD now carries `about[]` `DefinedTerm`s referencing the set; raw `keywords` stay for free-text search.

## #5 — Per-topic landing pages
- **`/lessons/topic/[slug]`** (13 pages): lists the topic's lessons, links the related standard, self-canonical, indexable. Doubles as the `DefinedTerm` page (it *is* the term's `@id`), so #2 and #5 reuse one URL instead of a parallel `/terms/` tree.
- **`/lessons/topic`**: index of all terms with live lesson counts.
- **`/lessons`**: canonicalizes to the unfiltered URL and marks filtered query-param states `noindex,follow`, so the static landing pages are the crawlable entry points (not the infinite filter permutations). Adds a "browse by topic" link.

## Verification
- `npm run build` green; 92 pages (was 78) — 13 topic pages + 1 index.
- Confirmed in built HTML: `skos:closeMatch` crosswalks on term pages, `about[]` DefinedTerms on lessons, `DefinedTermSet` on the index, canonical + noindex script on `/lessons`.
- Browser-checked the topic index and a term page (breadcrumbs, counts, related-standard link, lesson list all render).

## Notes
- The term `@id`s use the real site origin (`https://ucospo.net`) via `Astro.site`.
- ACM CCS is treated as a secondary authority (no row-level URIs available), per the report; primary anchors are the maintained schemes above.