### PR TITLE
Pathway copy refresh + dead category-icon cleanup

### DIFF
--- a/src/components/home/CategoryIcon.tsx
+++ b/src/components/home/CategoryIcon.tsx
@@ -3,8 +3,6 @@ import {
   PuzzlePieceIcon,
   UserGroupIcon,
   WrenchScrewdriverIcon,
-  SparklesIcon,
-  ScaleIcon,
   PresentationChartLineIcon,
 } from '@heroicons/react/24/outline';
 import type { CategoryIconName } from './types';
@@ -29,8 +27,6 @@ export default function CategoryIcon({
     'getting-started': <PuzzlePieceIcon style={style} />,
     contributing:      <UserGroupIcon style={style} />,
     maintaining:       <WrenchScrewdriverIcon style={style} />,
-    'building-communities': <SparklesIcon style={style} />,
-    licensing:         <ScaleIcon style={style} />,
     strategic:         <PresentationChartLineIcon style={style} />,
   };
 

--- a/src/components/home/types.ts
+++ b/src/components/home/types.ts
@@ -4,8 +4,6 @@ export type CategoryIconName =
   | 'getting-started'
   | 'contributing'
   | 'maintaining'
-  | 'building-communities'
-  | 'licensing'
   | 'strategic';
 
 export interface HomepagePathwaySection {

--- a/src/content/pathways/contributing.json
+++ b/src/content/pathways/contributing.json
@@ -1,6 +1,6 @@
 {
     "name": "Contributing to a Project",
-    "description": "For those ready to write code, open issues, or create documentation.",
+    "description": "For those building the craft of contributing: code, issues, and docs, plus testing, packaging, and reproducible workflows.",
     "icon": "🤝",
     "order": 2
 }

--- a/src/content/pathways/maintaining.json
+++ b/src/content/pathways/maintaining.json
@@ -1,6 +1,6 @@
 {
     "name": "Maintaining & Sustaining Software",
-    "description": "For maintainers, project leads, and tech stewards.",
+    "description": "For maintainers keeping an existing project healthy, secure, and sustainable.",
     "icon": "🛠",
     "order": 3
 }

--- a/src/content/pathways/strategic.json
+++ b/src/content/pathways/strategic.json
@@ -1,6 +1,6 @@
 {
     "name": "Strategic Practices & Career Development",
-    "description": "For project leaders, RSEs, and open science strategists.",
+    "description": "For people leading, sustaining, and growing projects: governance, metrics, licensing, and career.",
     "icon": "📈",
     "order": 6
 }


### PR DESCRIPTION
The two cosmetic follow-ups flagged after the pathway reconcile (#157).

- **Pathway descriptions** now match their post-reconcile contents:
  - *Contributing* — was "write code, open issues, or create documentation"; now mentions the technical craft (testing, packaging, reproducible workflows) folded in.
  - *Maintaining* — tightened to maintainers keeping an existing project healthy/secure/sustainable (project leads moved to Strategic).
  - *Strategic* — now reflects governance, metrics, licensing, and career.
- **Dead code**: removed the retired `building-communities` and `licensing` members from `CategoryIconName` and the icon map, plus their unused `SparklesIcon`/`ScaleIcon` imports.

`npm run build` green (92 pages); no remaining references to the removed icons.