### PR TITLE
Fix base-aware term URLs; advertise the lessons JSON API

### DIFF
--- a/src/data/topics.ts
+++ b/src/data/topics.ts
@@ -126,12 +126,21 @@ export function topicByCode(code: string): TopicTerm | undefined {
   return BY_CODE.get(code);
 }
 
-/** Absolute @id for a term, e.g. https://ucospo.net/lessons/topic/<code>. */
+// Build a deployed absolute URL, honoring the site's base path (`/education/`
+// in production) and Astro's trailing-slash output, so these @ids match the
+// pages' own canonical URLs exactly.
+function absoluteUrl(site: URL | undefined, path: string): string {
+  const base = import.meta.env.BASE_URL; // "/education/" in prod, "/" in dev
+  const joined = `${base.replace(/\/$/, "")}/${path.replace(/^\//, "")}`.replace(/\/?$/, "/");
+  return new URL(joined, site ?? "https://ucospo.net").href;
+}
+
+/** Absolute @id for a term, e.g. https://ucospo.net/education/lessons/topic/<code>/. */
 export function termId(site: URL | undefined, termCode: string): string {
-  return new URL(`${TERM_SET_PATH}/${termCode}`, site ?? "https://ucospo.net").href;
+  return absoluteUrl(site, `lessons/topic/${termCode}`);
 }
 
 /** Absolute @id for the DefinedTermSet itself. */
 export function termSetId(site: URL | undefined): string {
-  return new URL(TERM_SET_PATH, site ?? "https://ucospo.net").href;
+  return absoluteUrl(site, "lessons/topic");
 }

--- a/src/pages/lessons.astro
+++ b/src/pages/lessons.astro
@@ -17,8 +17,30 @@ const pagefindPath = `${import.meta.env.BASE_URL}pagefind/`;
 const pathways = await getCollection("pathways");
 const pathwayNames = Object.fromEntries(pathways.map((p) => [p.id, p.data.name]));
 
+const site = Astro.site ?? new URL("https://ucospo.net");
 const base = import.meta.env.BASE_URL;
-const canonicalUrl = new URL("/lessons", Astro.site ?? "https://ucospo.net").href;
+const canonicalUrl = new URL(Astro.url.pathname, site).href;
+const apiUrl = new URL(`${base}api/lessons.json`, site).href;
+
+// The lesson catalog, advertised as a machine-readable Dataset whose
+// distribution is the JSON API. This is the schema.org / Dataset Search
+// convention for "here is the data behind this collection."
+const datasetJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "@id": canonicalUrl,
+  name: "UC OSPO Education: Lesson Catalog",
+  description:
+    "Catalog of curated open source and research software education lessons from the UC OSPO Network, with topics, pathways, audiences, and repository health.",
+  url: canonicalUrl,
+  isAccessibleForFree: true,
+  creator: { "@type": "Organization", name: "UC OSPO Network", url: new URL(base, site).href },
+  distribution: {
+    "@type": "DataDownload",
+    encodingFormat: "application/json",
+    contentUrl: apiUrl,
+  },
+};
 ---
 
 <BaseLayout
@@ -27,6 +49,11 @@ const canonicalUrl = new URL("/lessons", Astro.site ?? "https://ucospo.net").hre
 >
   <Fragment slot="head">
     <link rel="canonical" href={canonicalUrl} />
+    {/* Machine-readable catalog: advertise the JSON API as an alternate
+        representation (rel=alternate, like RSS autodiscovery) and as a
+        schema.org Dataset distribution. */}
+    <link rel="alternate" type="application/json" href={apiUrl} title="Lessons catalog (JSON)" />
+    <script type="application/ld+json" set:html={JSON.stringify(datasetJsonLd)} />
     {/* Filtered states (?topic=…&role=…) are crawl noise; the topic landing
         pages are the indexable entry points. Base /lessons stays indexable. */}
     <script is:inline>

--- a/src/pages/lessons/topic/[slug].astro
+++ b/src/pages/lessons/topic/[slug].astro
@@ -2,7 +2,7 @@
 import BaseLayout from "../../../layouts/BaseLayout.astro";
 import LessonCard from "../../../components/LessonCard.jsx";
 import { getActiveLessons, type Lesson } from "../../../lib/lessons";
-import { TOPIC_TERMS, topicByCode, termId, termSetId, TERM_SET_PATH, type TopicTerm } from "../../../data/topics";
+import { TOPIC_TERMS, termId, termSetId, type TopicTerm } from "../../../data/topics";
 import githubHealthRaw from "../../../data/github-health.json";
 import type { HealthSnapshot } from "../../../lib/githubHealth";
 import "../../../components/lessons/lessons.css";
@@ -31,7 +31,7 @@ const lessonIndex = Object.fromEntries(
 );
 
 const base = import.meta.env.BASE_URL;
-const canonicalUrl = new URL(`${TERM_SET_PATH}/${term.termCode}`, Astro.site ?? "https://ucospo.net").href;
+const canonicalUrl = termId(Astro.site, term.termCode);
 
 // DefinedTerm with a SKOS closeMatch to the external authority. Mixing
 // schema.org and SKOS needs a context object; this is the formal crosswalk.

--- a/src/pages/lessons/topic/index.astro
+++ b/src/pages/lessons/topic/index.astro
@@ -1,7 +1,7 @@
 ---
 import BaseLayout from "../../../layouts/BaseLayout.astro";
 import { getActiveLessons } from "../../../lib/lessons";
-import { TOPIC_TERMS, termId, termSetId, TERM_SET_PATH } from "../../../data/topics";
+import { TOPIC_TERMS, termId, termSetId } from "../../../data/topics";
 
 const lessons = await getActiveLessons();
 
@@ -11,7 +11,7 @@ for (const lesson of lessons) {
 }
 
 const base = import.meta.env.BASE_URL;
-const canonicalUrl = new URL(TERM_SET_PATH, Astro.site ?? "https://ucospo.net").href;
+const canonicalUrl = termSetId(Astro.site);
 
 // The published DefinedTermSet: each term carries its external crosswalk as a
 // SKOS closeMatch so the set is a small, formally grounded RDF layer.

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -19,6 +19,7 @@ export const GET: APIRoute = async (context) => {
     `Lessons: ${base}/education/lessons`,
     `Pathways: ${base}/education/pathways`,
     `RSS: ${base}/education/rss.xml`,
+    `API (JSON): ${base}/education/api/lessons.json`,
     '',
     '## Pathways',
   ];


### PR DESCRIPTION
Two related changes about absolute URLs and machine discoverability.

## 1. Fix a canonical/`@id` regression from #158
The topic term `@id`s and canonical links were built with `new URL("/lessons/topic/…", Astro.site)`, which **drops the site's `/education` base path** — so canonicals pointed at `https://ucospo.net/lessons/topic/…` (a non-existent URL) instead of `…/education/lessons/topic/…`. Canonicals pointing at 404s actively hurt SEO.

- `termId` / `termSetId` now honor `import.meta.env.BASE_URL` and Astro's trailing-slash output, so each `@id` matches the page's real canonical.
- `/lessons` canonical now derives from `Astro.url.pathname`.
- Verified in `dist`: every term URL is now `…/education/lessons/topic/<code>/`, and a full scan finds zero stray non-`/education` topic URLs.

## 2. Advertise `/education/api/lessons.json` (it was undiscoverable)
The catalog API existed but nothing pointed to it. Added the standard conventions:
- **`rel="alternate" type="application/json"`** autodiscovery link on `/lessons` (same mechanism as RSS autodiscovery).
- **schema.org `Dataset`** JSON-LD with a `DataDownload` distribution → the JSON (Google Dataset Search / data-portal convention).
- **`llms.txt`** now lists the API endpoint for AI agents.
- (CORS `Access-Control-Allow-Origin: *` was already set on the endpoint.)

`npm run build` green (92 pages). All four outputs confirmed in built HTML.