### PR TITLE
fix(discoverability): base-path-aware URLs, RSS 404, orphaned lesson pages

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,1 @@
+Sitemap: https://ucospo.net/education/sitemap-index.xml

--- a/src/data/topics.ts
+++ b/src/data/topics.ts
@@ -9,6 +9,8 @@
 // The term set lives at /lessons/topic; each term at /lessons/topic/<termCode>,
 // which doubles as the human browse page (#5) and the DefinedTerm @id (#2).
 
+import { absoluteUrl } from "../lib/urls";
+
 export interface TopicCrosswalk {
   /** Human label for the external authority. */
   label: string;
@@ -124,15 +126,6 @@ export function topicByName(name: string): TopicTerm | undefined {
 
 export function topicByCode(code: string): TopicTerm | undefined {
   return BY_CODE.get(code);
-}
-
-// Build a deployed absolute URL, honoring the site's base path (`/education/`
-// in production) and Astro's trailing-slash output, so these @ids match the
-// pages' own canonical URLs exactly.
-function absoluteUrl(site: URL | undefined, path: string): string {
-  const base = import.meta.env.BASE_URL; // "/education/" in prod, "/" in dev
-  const joined = `${base.replace(/\/$/, "")}/${path.replace(/^\//, "")}`.replace(/\/?$/, "/");
-  return new URL(joined, site ?? "https://ucospo.net").href;
 }
 
 /** Absolute @id for a term, e.g. https://ucospo.net/education/lessons/topic/<code>/. */

--- a/src/lib/urls.ts
+++ b/src/lib/urls.ts
@@ -1,0 +1,18 @@
+// Build a deployed absolute URL, honoring the site's base path (`/education/`
+// in production) and Astro's trailing-slash output, so these URLs match the
+// pages' own canonical URLs exactly.
+export function absoluteUrl(site: URL | undefined, path: string): string {
+  const base = import.meta.env.BASE_URL; // "/education/" in prod, "/" in dev
+  const joined = `${base.replace(/\/$/, "")}/${path.replace(/^\//, "")}`.replace(/\/?$/, "/");
+  return new URL(joined, site ?? "https://ucospo.net").href;
+}
+
+// Same base-path resolution as absoluteUrl(), but for file-based endpoints
+// (rss.xml, api/lessons.json, llms.txt, robots.txt) that must NOT get a
+// trailing slash — these are static files on GitHub Pages, not directory
+// routes, so a trailing slash 404s.
+export function absoluteFileUrl(site: URL | undefined, path: string): string {
+  const base = import.meta.env.BASE_URL; // "/education/" in prod, "/" in dev
+  const joined = `${base.replace(/\/$/, "")}/${path.replace(/^\//, "")}`;
+  return new URL(joined, site ?? "https://ucospo.net").href;
+}

--- a/src/pages/api/lessons.json.ts
+++ b/src/pages/api/lessons.json.ts
@@ -2,12 +2,12 @@ import type { APIRoute } from 'astro';
 import { getLessons } from '../../lib/lessons';
 import type { HealthSnapshot } from '../../lib/githubHealth';
 import githubHealthRaw from '../../data/github-health.json';
+import { absoluteUrl } from '../../lib/urls';
 
 const healthData = githubHealthRaw as unknown as HealthSnapshot;
 
-export const GET: APIRoute = async () => {
+export const GET: APIRoute = async (context) => {
   const lessons = await getLessons();
-  const siteUrl = 'https://ucospo.net/education';
   const healthLessons = healthData.lessons ?? {};
 
   const catalog = lessons
@@ -18,7 +18,7 @@ export const GET: APIRoute = async () => {
       return {
         name: l.name,
         slug: l.slug,
-        url: `${siteUrl}/lessons/${l.slug}`,
+        url: absoluteUrl(context.site, `lessons/${l.slug}`),
         externalUrl: l.url || null,
         repoUrl: l.repoUrl || null,
         description: l.description || null,

--- a/src/pages/lessons/[slug].astro
+++ b/src/pages/lessons/[slug].astro
@@ -2,7 +2,7 @@
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import LessonJsonLd from "../../components/LessonJsonLd.astro";
 import Citation from "../../components/Citation.astro";
-import { getLessons, getRelatedLessons, type Lesson, teachingTime, isCreatedByUs } from "../../lib/lessons";
+import { getLessons, getActiveLessons, getRelatedLessons, type Lesson, teachingTime, isCreatedByUs } from "../../lib/lessons";
 import { lookupProvider } from "../../lib/providers";
 import { normalizeCitation } from "../../lib/citation";
 import { getCollection } from "astro:content";
@@ -20,15 +20,15 @@ type Props = {
 };
 
 export async function getStaticPaths() {
-  const [lessons, pathways] = await Promise.all([getLessons(), getCollection("pathways")]);
+  const [lessons, activeLessons, pathways] = await Promise.all([
+    getLessons(),
+    getActiveLessons(),
+    getCollection("pathways"),
+  ]);
   const pathwayMap = Object.fromEntries(pathways.map((p) => [p.id, p.data.name]));
   const slugToName = Object.fromEntries(lessons.map((l) => [l.slug, l.name]));
 
-  const candidates = lessons.filter(
-    (lesson) => typeof lesson.slug === "string" && lesson.slug.trim().length > 0,
-  );
-
-  return candidates.map((lesson) => {
+  return activeLessons.map((lesson) => {
     const pathwayId = lesson.pathways[0] ?? "";
     const pathwayName = pathwayMap[pathwayId] ?? "";
     const relatedLessons = getRelatedLessons(lesson, lessons);

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from 'astro';
 import { getActiveLessons } from '../lib/lessons';
 import { getCollection } from 'astro:content';
+import { absoluteUrl, absoluteFileUrl } from '../lib/urls';
 
 export const GET: APIRoute = async (context) => {
   const [lessons, pathways] = await Promise.all([
@@ -9,23 +10,22 @@ export const GET: APIRoute = async (context) => {
   ]);
 
   const sortedPathways = pathways.sort((a, b) => a.data.order - b.data.order);
-  const base = context.site?.toString().replace(/\/$/, '') ?? '';
 
   const lines: string[] = [
     '# UC OSPO Education',
     '> Curated open source education lessons from the UC OSPO Network.',
     '',
-    `Site: ${base}/education/`,
-    `Lessons: ${base}/education/lessons`,
-    `Pathways: ${base}/education/pathways`,
-    `RSS: ${base}/education/rss.xml`,
-    `API (JSON): ${base}/education/api/lessons.json`,
+    `Site: ${absoluteUrl(context.site, '/')}`,
+    `Lessons: ${absoluteUrl(context.site, 'lessons')}`,
+    `Pathways: ${absoluteUrl(context.site, 'pathways')}`,
+    `RSS: ${absoluteFileUrl(context.site, 'rss.xml')}`,
+    `API (JSON): ${absoluteFileUrl(context.site, 'api/lessons.json')}`,
     '',
     '## Pathways',
   ];
 
   for (const pathway of sortedPathways) {
-    lines.push(`- ${pathway.data.name}: ${base}/education/pathways/${pathway.id}`);
+    lines.push(`- ${pathway.data.name}: ${absoluteUrl(context.site, `pathways/${pathway.id}`)}`);
     lines.push(`  ${pathway.data.description}`);
   }
 
@@ -37,7 +37,7 @@ export const GET: APIRoute = async (context) => {
       .map((id) => sortedPathways.find((p) => p.id === id)?.data.name)
       .filter(Boolean)
       .join(', ');
-    lines.push(`- [${lesson.name}](${base}/education/lessons/${slug})`);
+    lines.push(`- [${lesson.name}](${absoluteUrl(context.site, `lessons/${slug}`)})`);
     if (lesson.description) lines.push(`  ${lesson.description}`);
     if (pathwayNames) lines.push(`  Pathways: ${pathwayNames}`);
     if (lesson.educationalLevel) lines.push(`  Level: ${lesson.educationalLevel}`);

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,6 +1,7 @@
 import rss from '@astrojs/rss';
 import type { APIRoute } from 'astro';
 import { getActiveLessons } from '../lib/lessons';
+import { absoluteUrl } from '../lib/urls';
 
 export const GET: APIRoute = async (context) => {
   const lessons = await getActiveLessons();
@@ -17,7 +18,7 @@ export const GET: APIRoute = async (context) => {
       return {
         title: lesson.name,
         description: lesson.description || lesson.abstract || '',
-        link: `${context.site}lessons/${lesson.slug}`,
+        link: absoluteUrl(context.site, `lessons/${lesson.slug}`),
         pubDate: pubDate ? new Date(pubDate) : undefined,
         categories: lesson.keywords,
       };
@@ -26,7 +27,7 @@ export const GET: APIRoute = async (context) => {
   return rss({
     title: 'UC OSPO Education — New & Updated Lessons',
     description: 'Curated open source education lessons from the UC OSPO Network.',
-    site: context.site!,
+    site: absoluteUrl(context.site, '/'),
     items,
     customData: '<language>en-us</language>',
   });


### PR DESCRIPTION
## Summary

Phase 1 low-effort batch from the AI Discoverability Remediation Plan (audit delivered 2026-07-08):

- Extract `absoluteUrl()` out of `src/data/topics.ts` into shared `src/lib/urls.ts`; add `absoluteFileUrl()` for file-based endpoints (`rss.xml`, `api/lessons.json`) that must not get a trailing slash on GitHub Pages static hosting.
- Fix `rss.xml.ts`: channel and item links were built from `context.site` alone, dropping the `/education` base path — confirmed 404ing in production.
- Route `llms.txt.ts` and `api/lessons.json.ts` through the shared helpers, removing hardcoded `/education` and `https://ucospo.net/education` string literals.
- `lessons/[slug].astro`: `getStaticPaths()` now builds from `getActiveLessons()` instead of all 66 lessons, dropping 23 `drop`-status orphan pages that were sitemap-indexed with no real content (66 → 43 pages).
- Add `public/robots.txt` with a correct `Sitemap:` directive. (The root `ucospo.net/robots.txt` fix is a different codebase — out of scope here, tracked separately.)

## Test plan
- [x] `npm run build` succeeds, 43 lesson pages generated (down from 66; confirmed the 23 `drop`-status slugs are gone)
- [x] `npx astro check` — 0 errors
- [x] `dist/rss.xml` links are `/education`-prefixed, no `localhost`
- [x] `dist/llms.txt` RSS/API lines have no trailing slash (would 404 as static files); page links (Site/Lessons/Pathways) correctly trailing-slashed
- [x] `dist/api/lessons.json` `url` fields are base-path-correct
- [x] `dist/robots.txt` present with `Sitemap:` directive