### PR TITLE
fix(pathways): trim retired taxonomy values from all copies

### DIFF
--- a/docs/UI_UX_GUIDE.md
+++ b/docs/UI_UX_GUIDE.md
@@ -131,7 +131,7 @@ File: `src/components/home/CategoryIcon.tsx`
 Supported icon names are defined in `src/components/home/types.ts`:
 
 ```ts
-'getting-started' | 'contributing' | 'maintaining' | 'building-communities' | 'licensing' | 'strategic'
+'getting-started' | 'contributing' | 'maintaining' | 'strategic'
 ```
 
 Props:

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -92,8 +92,6 @@ Which learning pathways this lesson belongs to. Must match pathway slugs exactly
 * `getting-started` — Getting Started with Open Source
 * `contributing` — Contributing to a Project
 * `maintaining` — Maintaining & Sustaining Software
-* `building-communities` — Building Inclusive Communities
-* `licensing` — Understanding Licensing & Compliance
 * `strategic` — Strategic Practices & Career Development
 
 A lesson may appear in more than one pathway. Most lessons belong to one.

--- a/keystatic.config.ts
+++ b/keystatic.config.ts
@@ -4,8 +4,6 @@ const pathwayOptions = [
   { label: 'Getting Started with Open Source', value: 'getting-started' },
   { label: 'Contributing to a Project', value: 'contributing' },
   { label: 'Maintaining & Sustaining Software', value: 'maintaining' },
-  { label: 'Building Inclusive Communities', value: 'building-communities' },
-  { label: 'Understanding Licensing & Compliance', value: 'licensing' },
   { label: 'Strategic Practices & Career Development', value: 'strategic' },
 ] as const;
 

--- a/scripts/validate-lessons.js
+++ b/scripts/validate-lessons.js
@@ -17,8 +17,6 @@ const FALLBACK_LEARNER_CATEGORIES = new Set([
   'Getting Started with Open Source',
   'Contributing to a Project',
   'Maintaining & Sustaining Software',
-  'Building Community',
-  'Understanding Licensing & Compliance',
   'Strategic Practices & Career Development',
 ]);
 

--- a/src/pages/for-educators.astro
+++ b/src/pages/for-educators.astro
@@ -256,7 +256,7 @@ import EducatorToolkit from '../components/EducatorToolkit.astro';
         <div class="feature-card">
           <h3><span class="feature-icon" aria-hidden="true">📚</span> Structured Pathways</h3>
           <p>
-            Lessons are organized into six learning pathways, from getting started with open source
+            Lessons are organized into learning pathways, from getting started with open source
             to strategic practices and career development.
           </p>
         </div>
@@ -317,7 +317,7 @@ import EducatorToolkit from '../components/EducatorToolkit.astro';
             for 50-minute sessions, half-day workshops, or multi-day programs.
           </p>
           <p class="pathways-list">
-            Example: "Understanding Licensing & Compliance" for tech transfer professionals
+            Example: "Maintaining & Sustaining Software" pathway for a hands-on session on release and maintenance practices
           </p>
         </div>
 
@@ -436,22 +436,6 @@ import EducatorToolkit from '../components/EducatorToolkit.astro';
           <p>
             <strong>Best for:</strong> Advanced courses, project management, software engineering principles<br>
             <strong>Tip:</strong> Great for students transitioning from contributors to maintainers or project leads.
-          </p>
-        </div>
-
-        <div class="use-case">
-          <h4>Building Inclusive Communities</h4>
-          <p>
-            <strong>Best for:</strong> Ethics courses, community management, professional skills development<br>
-            <strong>Tip:</strong> Encourage discussion and reflection. These topics benefit from collaborative learning.
-          </p>
-        </div>
-
-        <div class="use-case">
-          <h4>Understanding Licensing & Compliance</h4>
-          <p>
-            <strong>Best for:</strong> Law & technology courses, research compliance, tech transfer training<br>
-            <strong>Tip:</strong> Use real-world examples. Have students analyze licenses for projects they use.
           </p>
         </div>
 

--- a/src/pages/glossary.astro
+++ b/src/pages/glossary.astro
@@ -119,8 +119,6 @@ const description =
           <li><strong>Getting Started with Open Source</strong> — for learners new to open source and open collaboration</li>
           <li><strong>Contributing to a Project</strong> — for those ready to write code, open issues, or create documentation</li>
           <li><strong>Maintaining &amp; Sustaining Software</strong> — for maintainers, project leads, and tech stewards</li>
-          <li><strong>Building Inclusive Communities</strong> — for those organizing people, not just code</li>
-          <li><strong>Understanding Licensing &amp; Compliance</strong> — for anyone navigating open source legalities, especially in a UC context</li>
           <li><strong>Strategic Practices &amp; Career Development</strong> — for project leaders, RSEs, and open science strategists</li>
         </ul>
       </section>

--- a/src/pages/lessons.astro
+++ b/src/pages/lessons.astro
@@ -12,8 +12,8 @@ const healthData = githubHealthRaw as unknown as HealthSnapshot;
 const healthBySlug = healthData.lessons ?? {};
 const pagefindPath = `${import.meta.env.BASE_URL}pagefind/`;
 
-// Map pathway slug -> display name so the filter shows "Building Inclusive
-// Communities" rather than the raw "building-communities" slug.
+// Map pathway slug -> display name so the filter shows "Contributing to a
+// Project" rather than the raw "contributing" slug.
 const pathways = await getCollection("pathways");
 const pathwayNames = Object.fromEntries(pathways.map((p) => [p.id, p.data.name]));
 


### PR DESCRIPTION
## Summary

Item 6 from the AI Discoverability Remediation Plan — the pathway taxonomy trim.

Keystatic offered curators two pathway options — `building-communities` and `licensing` — with zero backing content pages. Confirmed via `jq` across all 66 lesson files that no lesson currently uses either value, so this is a clean trim, not a data migration.

- `keystatic.config.ts` — drop the two dead `pathwayOptions` entries
- `docs/schema.md`, `docs/UI_UX_GUIDE.md` — update stale docs to the real 4 values (`UI_UX_GUIDE`'s `CategoryIconName` list was already trimmed in code by #159, the doc just hadn't caught up)
- `src/pages/glossary.astro` — drop the two retired pathways from "Current pathways"
- `src/pages/for-educators.astro` — drop the "six learning pathways" count claim, swap the licensing example for a still-real pathway, remove the two dead Teaching Tips blocks
- `src/pages/lessons.astro` — fix a stale comment referencing the retired `building-communities` pathway
- `scripts/validate-lessons.js` — trim `FALLBACK_LEARNER_CATEGORIES` (legacy `learnerCategory` back-compat field) to match; no lesson currently sets `learnerCategory` at all

Left alone (real, unrelated things a broad grep also surfaces): `EducatorToolkit.astro`'s "Building Community" is an actual lesson title (`src/content/lessons/building-community.json`), not a pathway reference. Various one-off migration/audit scripts and generated report docs under `scripts/output/`, `.github/`, `STUDENT_README.md`, etc. reference the old `learnerCategory` normalization mapping historically — out of scope for this trim, don't affect any live page or current data.

## Test plan
- [x] `grep -rn "building-communities\|licensing"` across the 6 targeted files returns nothing (aside from unrelated "licensing" prose in for-educators.astro, read and confirmed it's about the topic taxonomy, not pathways)
- [x] `npm run build` succeeds
- [x] `npx astro check` — 0 errors
- [x] `node scripts/validate-lessons.js` passes, 66 lessons checked, 0 warnings