### PR TITLE
fix(staleness): split freshness check by content provenance

### DIFF
--- a/.github/scripts/check-staleness.mjs
+++ b/.github/scripts/check-staleness.mjs
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+/**
+ * Checks lesson freshness and prints a markdown report body to stdout.
+ *
+ * Split by provenance, not a uniform dateModified check:
+ * - Lessons we authored ourselves: checked against our own dateModified/
+ *   dateCreated. We own the content, so staleness here is actionable.
+ * - Curated (external) lessons: checked against the source repo's last
+ *   push (src/data/github-health.json, refreshed weekly by
+ *   refresh-github-health.yml) and whether that repo is now archived.
+ *   Our own dateModified for these mostly reflects when we last touched
+ *   the catalog entry, not whether the underlying lesson is current, so
+ *   it isn't a meaningful signal on its own.
+ *
+ * Usage:
+ *   node .github/scripts/check-staleness.mjs            # markdown report to stdout
+ *   node .github/scripts/check-staleness.mjs --json      # JSON report to stdout
+ */
+
+import { readFileSync, readdirSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, '..', '..');
+
+const STALE_MONTHS = 18;
+const LESSONS_DIR = join(REPO_ROOT, 'src/content/lessons');
+const HEALTH_FILE = join(REPO_ROOT, 'src/data/github-health.json');
+const LESSON_SITE_BASE = 'https://ucospo.net/education/lessons';
+const CREATOR_ORG = 'UC OSPO Network';
+
+const now = new Date();
+
+function isCreatedByUs(lesson) {
+  if ((lesson.provider || '').trim() === CREATOR_ORG) return true;
+  const haystack = `${lesson.repoUrl || ''} ${lesson.url || ''}`.toLowerCase();
+  return haystack.includes('uc-ospo-network') || haystack.includes('ucospo.net');
+}
+
+function parseDate(dateStr) {
+  if (!dateStr || typeof dateStr !== 'string') return null;
+  const trimmed = dateStr.trim();
+  if (!trimmed) return null;
+  const isoMatch = /^\d{4}-\d{2}-\d{2}$/.test(trimmed);
+  const date = isoMatch ? new Date(`${trimmed}T00:00:00Z`) : new Date(trimmed);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function monthsSince(date) {
+  return (now.getUTCFullYear() - date.getUTCFullYear()) * 12 + (now.getUTCMonth() - date.getUTCMonth());
+}
+
+function isStale(date) {
+  const monthDiff = monthsSince(date);
+  return monthDiff > STALE_MONTHS || (monthDiff === STALE_MONTHS && now.getUTCDate() > date.getUTCDate());
+}
+
+export function buildReport() {
+  const health = JSON.parse(readFileSync(HEALTH_FILE, 'utf8'));
+  const healthLessons = health.lessons || {};
+
+  const files = readdirSync(LESSONS_DIR).filter((f) => f.endsWith('.json')).sort();
+
+  const ownContentStale = [];
+  const curatedStale = [];
+  const curatedArchived = [];
+  const unknownFreshness = [];
+  let checked = 0;
+
+  for (const file of files) {
+    const lesson = JSON.parse(readFileSync(join(LESSONS_DIR, file), 'utf8'));
+    if (lesson.keepStatus === 'drop') continue;
+    if (lesson.creativeWorkStatus === 'Archived') continue;
+    checked += 1;
+
+    const slug = (lesson.slug && lesson.slug.trim()) || file.replace(/\.json$/, '');
+
+    if (isCreatedByUs(lesson)) {
+      const dateStr = (lesson.dateModified || lesson.dateCreated || '').trim();
+      if (!dateStr) continue;
+      const d = parseDate(dateStr);
+      if (d && isStale(d)) {
+        ownContentStale.push({ slug, name: lesson.name, dateStr, monthsOld: monthsSince(d) });
+      }
+      continue;
+    }
+
+    const h = healthLessons[slug];
+    if (!h) {
+      unknownFreshness.push({ slug, name: lesson.name });
+      continue;
+    }
+    if (h.archived) {
+      curatedArchived.push({ slug, name: lesson.name, repoUrl: lesson.repoUrl });
+      continue;
+    }
+    const pushedAtStr = h.pushedAt;
+    if (!pushedAtStr) {
+      unknownFreshness.push({ slug, name: lesson.name });
+      continue;
+    }
+    const pushedDate = parseDate(pushedAtStr);
+    if (pushedDate && isStale(pushedDate)) {
+      curatedStale.push({
+        slug,
+        name: lesson.name,
+        pushedAtStr,
+        monthsOld: monthsSince(pushedDate),
+        repoUrl: lesson.repoUrl,
+      });
+    }
+  }
+
+  return {
+    checked,
+    healthFetchedAt: health.fetchedAt || null,
+    ownContentStale,
+    curatedStale,
+    curatedArchived,
+    unknownFreshness,
+  };
+}
+
+export function renderMarkdown(report) {
+  const { checked, healthFetchedAt, ownContentStale, curatedStale, curatedArchived, unknownFreshness } = report;
+  const totalFlagged = ownContentStale.length + curatedStale.length + curatedArchived.length;
+  const lines = [];
+
+  lines.push('## Content staleness report');
+  lines.push('');
+  lines.push(
+    `${checked} active lessons checked. ${totalFlagged} flagged for review` +
+      (unknownFreshness.length > 0 ? `, ${unknownFreshness.length} with unknown freshness.` : '.'),
+  );
+  if (healthFetchedAt) {
+    lines.push(`Source-repo freshness data last refreshed: ${healthFetchedAt}.`);
+  }
+  lines.push('');
+
+  if (ownContentStale.length > 0) {
+    lines.push(`### Lessons we authored — ${ownContentStale.length} not updated in ${STALE_MONTHS}+ months`);
+    lines.push('');
+    lines.push('We own this content, so these are directly actionable.');
+    lines.push('');
+    for (const l of ownContentStale) {
+      lines.push(`- [${l.name}](${LESSON_SITE_BASE}/${l.slug}) — last modified ${l.dateStr} (${l.monthsOld} months ago)`);
+    }
+    lines.push('');
+  }
+
+  if (curatedArchived.length > 0) {
+    lines.push(`### Curated lessons whose source repo is now archived — ${curatedArchived.length}`);
+    lines.push('');
+    lines.push('The upstream project is archived. Consider whether to keep, replace, or drop these.');
+    lines.push('');
+    for (const l of curatedArchived) {
+      lines.push(`- [${l.name}](${LESSON_SITE_BASE}/${l.slug}) — [${l.repoUrl}](${l.repoUrl})`);
+    }
+    lines.push('');
+  }
+
+  if (curatedStale.length > 0) {
+    lines.push(`### Curated lessons with a stale source repo — ${curatedStale.length}`);
+    lines.push('');
+    lines.push(`Source repo hasn't been pushed to in ${STALE_MONTHS}+ months. May indicate an unmaintained project.`);
+    lines.push('');
+    for (const l of curatedStale) {
+      lines.push(
+        `- [${l.name}](${LESSON_SITE_BASE}/${l.slug}) — [source](${l.repoUrl}) last pushed ${l.pushedAtStr} (${l.monthsOld} months ago)`,
+      );
+    }
+    lines.push('');
+  }
+
+  if (unknownFreshness.length > 0) {
+    lines.push(`<details><summary>Unknown freshness — ${unknownFreshness.length} lessons (no repo health data)</summary>`);
+    lines.push('');
+    for (const l of unknownFreshness) {
+      lines.push(`- [${l.name}](${LESSON_SITE_BASE}/${l.slug})`);
+    }
+    lines.push('');
+    lines.push('</details>');
+    lines.push('');
+  }
+
+  lines.push('_This report is regenerated in place each run by the Lesson Staleness Check workflow. It is not a checklist — items drop off automatically once the underlying data changes (repo re-activated, dateModified updated, or the lesson set to keepStatus: drop)._');
+
+  return lines.join('\n');
+}
+
+function main() {
+  const report = buildReport();
+  if (process.argv.includes('--json')) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    console.log(renderMarkdown(report));
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/.github/workflows/staleness-check.yml
+++ b/.github/workflows/staleness-check.yml
@@ -15,56 +15,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Check for stale lessons and open issues
+      - name: Generate staleness report
+        run: node .github/scripts/check-staleness.mjs > staleness-report.md
+
+      - name: Post/update tracking issue
         uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');
-            const path = require('path');
 
-            const STALE_MONTHS = 18;
-            const LESSONS_DIR = 'src/content/lessons';
-            const LESSON_SITE_BASE = 'https://ucospo.net/education/lessons';
-            const LABEL = 'stale-lesson';
-            const now = new Date();
-
-            function getLessonSlug(file, lesson) {
-              const fromLesson = typeof lesson.slug === 'string' ? lesson.slug.trim() : '';
-              return fromLesson || file.replace(/\.json$/, '');
-            }
-
-            function parseDate(dateStr) {
-              if (!dateStr || typeof dateStr !== 'string') return null;
-              const trimmed = dateStr.trim();
-              if (!trimmed) return null;
-
-              const isoMatch = /^\d{4}-\d{2}-\d{2}$/.test(trimmed);
-              const date = isoMatch
-                ? new Date(`${trimmed}T00:00:00Z`)
-                : new Date(trimmed);
-
-              return Number.isNaN(date.getTime()) ? null : date;
-            }
-
-            function monthsSince(date) {
-              return (
-                (now.getUTCFullYear() - date.getUTCFullYear()) * 12 +
-                (now.getUTCMonth() - date.getUTCMonth())
-              );
-            }
-
-            function isStale(date) {
-              const monthDiff = monthsSince(date);
-              return monthDiff > STALE_MONTHS ||
-                (monthDiff === STALE_MONTHS && now.getUTCDate() > date.getUTCDate());
-            }
+            const LABEL = 'content-staleness-report';
+            const TITLE = 'Content staleness report';
+            const body = fs.readFileSync('staleness-report.md', 'utf8');
+            const hasFindings = /^### /m.test(body);
 
             try {
-              await github.rest.issues.getLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                name: LABEL,
-              });
+              await github.rest.issues.getLabel({ owner: context.repo.owner, repo: context.repo.repo, name: LABEL });
             } catch (error) {
               if (error.status === 404) {
                 await github.rest.issues.createLabel({
@@ -72,7 +38,7 @@ jobs:
                   repo: context.repo.repo,
                   name: LABEL,
                   color: 'fbca04',
-                  description: 'Automated review request for lessons with outdated metadata',
+                  description: 'Auto-updated report of lessons/pathways that may need a freshness review',
                 });
               } else {
                 throw error;
@@ -84,82 +50,44 @@ jobs:
               repo: context.repo.repo,
               labels: LABEL,
               state: 'open',
-              per_page: 100,
+              per_page: 10,
             });
+            const openIssue = existing.data.find((issue) => issue.title === TITLE);
 
-            const openTitles = new Set(existing.data.map((issue) => issue.title));
-            const files = fs.readdirSync(LESSONS_DIR).filter((f) => f.endsWith('.json')).sort();
-
-            let checked = 0;
-            let staleFound = 0;
-            let opened = 0;
-            let skippedDuplicate = 0;
-
-            for (const file of files) {
-              const lesson = JSON.parse(fs.readFileSync(path.join(LESSONS_DIR, file), 'utf8'));
-              checked += 1;
-
-              if (lesson.keepStatus === 'drop') continue;
-              if (lesson.creativeWorkStatus === 'Archived') continue;
-
-              const dateStr = (lesson.dateModified || lesson.dateCreated || '').trim();
-              if (!dateStr) continue;
-
-              const lastModified = parseDate(dateStr);
-              if (!lastModified) continue;
-
-              if (!isStale(lastModified)) continue;
-
-              staleFound += 1;
-              const issueTitle = `Review needed: ${lesson.name}`;
-              if (openTitles.has(issueTitle)) {
-                skippedDuplicate += 1;
-                continue;
+            if (!hasFindings) {
+              if (openIssue) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: openIssue.number,
+                  body: 'Nothing flagged in this run. Closing.',
+                });
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: openIssue.number,
+                  state: 'closed',
+                });
               }
-
-              const slug = getLessonSlug(file, lesson);
-              const monthsOld = monthsSince(lastModified);
-              const owner = lesson.campusOwner
-                ? ` Campus owner: **${lesson.campusOwner}**.`
-                : '';
-
-              await github.rest.issues.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                title: issueTitle,
-                labels: [LABEL],
-                body: [
-                  '## Lesson review requested',
-                  '',
-                  `**Lesson:** [${lesson.name}](${LESSON_SITE_BASE}/${slug})`,
-                  `**Last modified:** ${dateStr} (${monthsOld} months ago)`,
-                  `**External URL:** ${lesson.url || '—'}${owner}`,
-                  '',
-                  '### Checklist',
-                  '',
-                  '- [ ] External URL still resolves and content is current',
-                  '- [ ] Learning objectives still accurate',
-                  '- [ ] Metadata fields up to date (level, time, keywords)',
-                  '- [ ] `dateModified` updated in the lesson JSON after review',
-                  '- [ ] If lesson is no longer relevant, set `creativeWorkStatus: Archived`',
-                  '',
-                  '_This issue was opened automatically by the staleness detection workflow._',
-                ].join('\n'),
-              });
-
-              openTitles.add(issueTitle);
-              opened += 1;
+              console.log('No staleness findings this run.');
+              return;
             }
 
-            const summary = [
-              `Lessons checked: ${checked}`,
-              `Stale lessons found: ${staleFound}`,
-              `Issues opened: ${opened}`,
-              `Skipped (duplicate open issue): ${skippedDuplicate}`,
-            ].join('\n');
-
-            core.summary.addHeading('Lesson staleness check');
-            core.summary.addRaw(summary);
-            await core.summary.write();
-
-            console.log(summary);
+            if (openIssue) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: openIssue.number,
+                body,
+              });
+              console.log(`Updated tracking issue #${openIssue.number}.`);
+            } else {
+              const created = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: TITLE,
+                labels: [LABEL],
+                body,
+              });
+              console.log(`Opened tracking issue #${created.data.number}.`);
+            }


### PR DESCRIPTION
## Summary

The existing quarterly staleness check (`staleness-check.yml`) flagged every lesson uniformly by its own `dateModified`/`dateCreated` against an 18-month threshold, opening one GitHub issue per stale lesson. Its first run (2026-07-01) opened **20 issues** (#162-181) — almost all for curated external content, since only 1 of the 43 currently active lessons was actually authored by UC OSPO. Our `dateModified` on curated lessons mostly reflects when we last touched the catalog entry, not whether the underlying lesson is actually stale, so most of those issues weren't actionable. **Closed all 20** with an explanation pointing here.

## What changed

New `.github/scripts/check-staleness.mjs` splits the check by content provenance:
- **Lessons we authored** (`isCreatedByUs`, currently 1) — checked against our own `dateModified`/`dateCreated`. We own that content, so staleness here is directly actionable.
- **Curated lessons** (42 of 43) — checked against their source repo's last push and archived status (`src/data/github-health.json`, already refreshed weekly by `refresh-github-health.yml`) instead. That's a real signal of whether the upstream project is still maintained, which our own metadata doesn't capture.
- Lessons with no repo health data are reported separately as "unknown freshness" rather than silently skipped or falsely flagged.

The workflow now maintains a **single running tracking issue** (label `content-staleness-report`), regenerated in place each run, instead of one issue per lesson — avoids repeating the flood on the next quarterly run (Oct 1). If nothing is flagged, it closes the tracking issue with a note instead of leaving a stale "all clear" open forever.

## Test plan
- [x] Dry-ran the categorization logic locally against real repo data before writing the workflow — confirmed it goes from 20 flagged lessons down to 1 genuine finding (a source repo unpushed for 21 months) + 9 "unknown freshness"
- [x] `node .github/scripts/check-staleness.mjs` and `--json` mode both produce correct output locally
- [x] Manually triggered the workflow twice via `workflow_dispatch` on this branch against the live repo:
  - First run: opened tracking issue #186 with the expected content
  - Second run: updated #186 in place (confirmed idempotent, no duplicate issue)
- [x] YAML validated, ESM module imports cleanly